### PR TITLE
Feature/man page and shell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d9501bd3f5f09f7bbee01da9a511073ed30a80cd7a509f1214bb74eadea71ad"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,6 +167,16 @@ name = "clap_lex"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "clap_mangen"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b4c3c54b30f0d9adcb47f25f61fcce35c4dd8916638c6b82fbd5f4fb4179e2"
+dependencies = [
+ "clap",
+ "roff",
+]
 
 [[package]]
 name = "colorchoice"
@@ -289,6 +308,8 @@ dependencies = [
  "assert_cmd",
  "clap",
  "clap-verbosity-flag",
+ "clap_complete",
+ "clap_mangen",
  "env_logger",
  "log",
  "pest",
@@ -454,6 +475,12 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "roff"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3"
 
 [[package]]
 name = "ryu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ pest_derive = "2.8.1"
 regex = "1.11.1"
 serde = { version = "1.0.219", features = ["derive"]}
 serde_json = "1.0.142"
+clap_mangen = "0.2.29"
+clap_complete = "4.5.57"
 
 [dev-dependencies]
 assert_cmd = "2.0"
@@ -36,3 +38,4 @@ name = "jg"
 [[test]]
 name = "cli"
 path = "tests/cli.rs"
+

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ be redirected to your shell's expected completion location:
   echo 'source /path/to/jg.bash' >> ~/.bashrc
 
   # Or copy to the system-wide bash completion directory
-  jg generate shell bash > jg.fish && sudo mv jg.fish /etc/bash_completion.d/
+  jg generate shell bash > jg.bash && sudo mv jg.bash /etc/bash_completion.d/
   ```
 
 - Zsh

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 - [Usage](#usage)
   - [Query Syntax](#query-syntax)
 - [Examples](#examples)
+- [Shell Completions](#shell-completions)
+- [Man Page](#man-page)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -24,12 +26,16 @@ The `jg` binary will be installed to `~/.cargo/bin`.
 ## Usage
 
 ```
-Query an input JSON document against a jsongrep query
+A JSONPath-inspired query language for JSON documents
 
-Usage: jg [OPTIONS] <QUERY> [FILE]
+Usage: jg [OPTIONS] [QUERY] [FILE] [COMMAND]
+
+Commands:
+  generate  Generate additional documentation and/or completions
+  help      Print this message or the help of the given subcommand(s)
 
 Arguments:
-  <QUERY>  Query string (e.g., "**.name")
+  [QUERY]  Query string (e.g., "**.name")
   [FILE]   Optional path to JSON file. If omitted, reads from STDIN
 
 Options:
@@ -46,13 +52,22 @@ Options:
 The query engine allows you to query JSON data using a simple DSL. It supports
 the following operators:
 
-- Field accesses: `"foo"`
-- Array accesses (0-indexed): `"[0]" | "[start: end]"`
-- Field and array wild cards: `"foo.*", "foo[*]"`
-- Optional chaining: `"foo?.bar"`
-- Kleene star: `"foo*"`
-- Disjunction: `"foo | bar"`
-- Sequence: `"foo.bar.baz"`
+- Field accesses: `foo`
+- Array accesses (0-indexed): `[0] | [start: end]`
+- Field and array wild cards: `foo.*`, `foo[*]`
+- Optional chaining: `foo?.bar`
+- Kleene star: `foo*`
+- Disjunction: `foo | bar`
+- Sequence: `foo.bar.baz`
+
+**Notes**:
+
+- Sequences use `.` to chain steps: `foo.bar.baz`
+
+- Fields can be unquoted (`foo`) or quoted (`"foo bar"`)
+
+- The `*` modifier after a step is different from the `*` field wildcard — the
+  modifier repeats **the preceding step**.
 
 The complete grammar for the query language can be found in the
 [grammar](./src/query/grammar) directory.
@@ -126,7 +141,7 @@ Found matches: 2
 ---
 
 <details>
-<summary>QueryBuilder API</summary>
+<summary>Rust API: QueryBuilder</summary>
 
 The `jsongrep::query::ast` module defines the `QueryBuilder` fluent API for
 building queries. It allows you to construct queries using a builder pattern.
@@ -151,6 +166,50 @@ let query = QueryBuilder::new()
 
 Examples of using the `jsongrep` crate can be found in the
 [examples](./examples) directory.
+
+## Shell Completions
+
+To generate completions for your shell, you can use the `jg generate shell`
+subcommand. By default, the completions will be printed to `/dev/stdout` and can
+be redirected to your shell's expected completion location:
+
+- Bash
+
+  ```bash
+  # Source the completion script in your .bashrc
+  echo 'source /path/to/jg.bash' >> ~/.bashrc
+
+  # Or copy to the system-wide bash completion directory
+  jg generate shell bash > jg.fish && sudo mv jg.fish /etc/bash_completion.d/
+  ```
+
+- Zsh
+
+  ```bash
+  mkdir -p ~/.zsh/completions
+  jg generate shell zsh > ~/.zsh/completions/_jg
+
+  # Add the directory to fpath in your .zshrc before compinit
+  echo 'fpath=(~/.zsh/completions $fpath)' >> ~/.zshrc
+  echo 'autoload -Uz compinit && compinit' >> ~/.zshrc
+  ```
+
+- Fish
+
+  ```bash
+  jg generate shell fish > ~/.config/fish/completions/jg.fish
+  ```
+
+## Man Page
+
+To generate a Man page for `jg`, you can use the `jg generate man`
+subcommand. By default, the Man page will be printed to `/dev/stdout` and can
+be redirected to your local Man folder:
+
+```bash
+mkdir -p ~/.local/share/man/man1/
+jg generate man > ~/.local/share/man/man1/jg.1
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -202,14 +202,16 @@ be redirected to your shell's expected completion location:
 
 ## Man Page
 
-To generate a Man page for `jg`, you can use the `jg generate man`
-subcommand. By default, the Man page will be printed to `/dev/stdout` and can
-be redirected to your local Man folder:
+To generate a Man page for `jg`, you can use the `jg generate man` subcommand to
+generate to a specified output directory with the `-o`/`--output-dir` options
+(defaults to current directory):
 
 ```bash
 mkdir -p ~/.local/share/man/man1/
-jg generate man > ~/.local/share/man/man1/jg.1
+jg generate man -o ~/.local/share/man/man1/
 ```
+
+Browse the generated Man pages with `man jg`.
 
 ## Contributing
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,9 @@ Main binary for jsongrep.
 
 use anyhow::{Context, Result};
 use clap::CommandFactory;
-use clap::{ArgAction, Parser};
-use std::io;
+use clap::{ArgAction, Parser, Subcommand};
+use clap_complete::generate;
+use std::io::{self, Write, stdout};
 use std::{
     fs,
     io::{IsTerminal, Read},
@@ -15,11 +16,14 @@ use std::{
 use jsongrep::{query::*, schema::JSONValue};
 
 /// Query an input JSON document against a jsongrep query.
-#[derive(Parser, Debug)]
+#[derive(Parser)]
 #[command(version, about, arg_required_else_help = true, long_about = None)]
 struct Args {
+    /// Optional subcommands
+    #[command(subcommand)]
+    command: Option<Commands>,
     /// Query string (e.g., "**.name")
-    query: String,
+    query: Option<String>,
     #[arg(value_name = "FILE")]
     /// Optional path to JSON file. If omitted, reads from STDIN
     input: Option<PathBuf>,
@@ -37,6 +41,23 @@ struct Args {
     no_display: bool,
 }
 
+/// Available subcommands for `jg`
+#[derive(Subcommand)]
+enum Commands {
+    #[command(subcommand)]
+    /// Generate additional documentation and/or completions
+    Generate(GenerateCommand),
+}
+
+/// Generate shell completions and man page
+#[derive(Subcommand)]
+enum GenerateCommand {
+    /// Generate shell completions for the given shell to stdout.
+    Shell { shell: clap_complete::Shell },
+    /// Generate a man page for jg to stdout.
+    Man,
+}
+
 /// Entry point for main binary.
 ///
 /// This parses the command line arguments and executes the query. If the input
@@ -45,56 +66,81 @@ struct Args {
 fn main() -> Result<()> {
     let args = Args::parse();
 
-    // Parse query
-    let query: Query =
-        args.query.parse().with_context(|| "Failed to parse query")?;
+    match args.command {
+        Some(Commands::Generate(cmd)) => match cmd {
+            GenerateCommand::Shell { shell } => {
+                let mut cmd = Args::command();
+                generate(shell, &mut cmd, "jg", &mut stdout().lock())
+            }
+            GenerateCommand::Man => {
+                let cmd = Args::command();
+                let man = clap_mangen::Man::new(cmd.clone());
+                let mut buffer: Vec<u8> = Vec::new();
+                man.render(&mut buffer)?;
+                stdout().lock().write_all(&buffer)?;
+            }
+        },
+        None => {
+            // Parse query
+            let query: Query = args
+                .query
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Query string required unless using subcommand"
+                    )
+                })?
+                .parse()
+                .with_context(|| "Failed to parse query")?;
 
-    // Parse input content
-    let input_content = if let Some(path) = args.input {
-        fs::read_to_string(&path)
-            .with_context(|| format!("Failed to read file {:?}", path))?
-    } else {
-        if io::stdin().is_terminal() {
-            // No piped input and no file specified
-            let mut cmd = Args::command();
-            return Ok(cmd.print_help()?);
-        }
-        let mut buffer = String::new();
-        io::stdin().read_to_string(&mut buffer)?;
-        buffer
-    };
-    let json = JSONValue::try_from(input_content.as_str())
-        .with_context(|| "Failed to parse JSON")?;
+            // Parse input content
+            let input_content = if let Some(path) = args.input {
+                fs::read_to_string(&path).with_context(|| {
+                    format!("Failed to read file {:?}", path)
+                })?
+            } else {
+                if io::stdin().is_terminal() {
+                    // No piped input and no file specified
+                    let mut cmd = Args::command();
+                    return Ok(cmd.print_help()?);
+                }
+                let mut buffer = String::new();
+                io::stdin().read_to_string(&mut buffer)?;
+                buffer
+            };
+            let json = JSONValue::try_from(input_content.as_str())
+                .with_context(|| "Failed to parse JSON")?;
 
-    // Execute query
-    let results = DFAQueryEngine.find(&json, &query);
+            // Execute query
+            let results = DFAQueryEngine.find(&json, &query);
 
-    // Display output
-    if args.count {
-        println!("Found matches: {}", results.len());
-    }
+            // Display output
+            if args.count {
+                println!("Found matches: {}", results.len());
+            }
 
-    // Display depth
-    if args.depth {
-        println!("Document depth: {}", json.depth())
-    }
+            // Display depth
+            if args.depth {
+                println!("Document depth: {}", json.depth())
+            }
 
-    if !args.no_display {
-        if !args.compact {
-            // Pretty-printed output
-            let json_values: Vec<&JSONValue> =
-                results.iter().map(|p| p.value).collect();
-            println!("{}", serde_json::to_string_pretty(&json_values)?);
-        } else {
-            // Compact output
-            let json_output: Vec<String> = results
-                .iter()
-                .map(|p| {
-                    serde_json::to_string(p.value)
-                        .unwrap_or_else(|_| "".to_string())
-                })
-                .collect();
-            println!("{}", serde_json::to_string(&json_output)?);
+            if !args.no_display {
+                if !args.compact {
+                    // Pretty-printed output
+                    let json_values: Vec<&JSONValue> =
+                        results.iter().map(|p| p.value).collect();
+                    println!("{}", serde_json::to_string_pretty(&json_values)?);
+                } else {
+                    // Compact output
+                    let json_output: Vec<String> = results
+                        .iter()
+                        .map(|p| {
+                            serde_json::to_string(p.value)
+                                .unwrap_or_else(|_| "".to_string())
+                        })
+                        .collect();
+                    println!("{}", serde_json::to_string(&json_output)?);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

### Summary 

- Added `generate` subcommand to generate shell completions and Man pages with `clap_complete` and `clap_mangen`, respectively

- Usage:

```
Generate additional documentation and/or completions

Usage: jg generate <COMMAND>

Commands:
  shell  Generate shell completions for the given shell to stdout
  man    Generate a man page for jg to output directory if specified, else the current directory
  help   Print this message or the help of the given subcommand(s)

Options:
  -h, --help  Print help
```

- Updated README with instructions on generating completions and Man pages.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

<img width="2032" height="1167" alt="Screenshot 2025-08-14 at 8 12 23 PM" src="https://github.com/user-attachments/assets/998237a7-380f-40ea-b857-eea062e6b85d" />

<img width="647" height="187" alt="Screenshot 2025-08-14 at 8 14 35 PM" src="https://github.com/user-attachments/assets/28d4f5fa-9124-4e7b-aad3-97844074d087" />

## Testing (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->
