### PR TITLE
refactor(cli): `--porcelain` flag, make `--count`/ `--depth`  mutually exclusive, `--depth` with query

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ $ curl -s https://api.nobelprize.org/v1/prize.json | jq '.prizes[0] | .year, .ca
 
 ```bash
 # jsongrep
-$ curl -s https://api.nobelprize.org/v1/prize.json | jg -F firstname --count -n
+$ curl -s https://api.nobelprize.org/v1/prize.json | jg -F firstname --count
 Found matches: 1026
 
 # jq
@@ -298,6 +298,7 @@ Options:
       --compact          Do not pretty-print the JSON output
       --count            Display count of number of matches
       --depth            Display depth of the input document
+      --porcelain        Machine-readable output: strip labels and colors (useful for piping)
   -n, --no-display       Do not display matched JSON values
   -F, --fixed-string     Treat the query as a literal field name and search at any depth
       --with-path        Always print the path header, even when output is piped
@@ -318,7 +319,7 @@ curl -s https://api.nobelprize.org/v1/prize.json | jg -F motivation | head -4
 **Count matches without displaying them:**
 
 ```bash
-curl -s https://api.nobelprize.org/v1/prize.json | jg -F firstname --count -n
+curl -s https://api.nobelprize.org/v1/prize.json | jg -F firstname --count
 # Found matches: 1026
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,11 +50,14 @@ struct Args {
     #[arg(long, action = ArgAction::SetTrue)]
     compact: bool,
     /// Display count of number of matches
-    #[arg(long, action = ArgAction::SetTrue)]
+    #[arg(long, action = ArgAction::SetTrue, conflicts_with = "depth")]
     count: bool,
     /// Display depth of the input document
-    #[arg(long, action = ArgAction::SetTrue)]
+    #[arg(long, action = ArgAction::SetTrue, conflicts_with = "count")]
     depth: bool,
+    /// Machine-readable output: strip labels and colors (useful for piping)
+    #[arg(long, action = ArgAction::SetTrue)]
+    porcelain: bool,
     /// Do not display matched JSON values
     #[arg(short, long, action = ArgAction::SetTrue)]
     no_display: bool,
@@ -308,7 +311,7 @@ fn detect_format(path: Option<&PathBuf>, explicit: Format) -> Format {
 /// is piped in, it reads from STDIN. The output is printed to STDOUT, with
 /// formatting determined by the command line arguments.
 fn main() -> Result<()> {
-    let args = Args::parse();
+    let mut args = Args::parse();
 
     match args.command {
         Some(Commands::Generate(cmd)) => match cmd {
@@ -384,23 +387,35 @@ fn main() -> Result<()> {
 
             let mut writer = BufWriter::new(stdout);
 
+            if args.count || args.depth {
+                args.no_display = true;
+            }
+
             if args.count {
-                writeln!(
-                    writer,
-                    "{} {}",
-                    "Found matches:".bold().blue(),
-                    results.len()
-                )
-                .with_context(|| "Failed to write to stdout")?;
+                if args.porcelain {
+                    writeln!(writer, "{}", results.len())?;
+                } else {
+                    writeln!(
+                        writer,
+                        "{} {}",
+                        "Found matches:".bold().blue(),
+                        results.len()
+                    )
+                    .with_context(|| "Failed to write to stdout")?;
+                }
             }
 
             if args.depth {
-                writeln!(
-                    writer,
-                    "{} {}",
-                    "Depth:".bold().blue(),
-                    depth(&json)
-                )?;
+                if args.porcelain {
+                    writeln!(writer, "{}", depth(&json))?;
+                } else {
+                    writeln!(
+                        writer,
+                        "{} {}",
+                        "Depth:".bold().blue(),
+                        depth(&json)
+                    )?;
+                }
             }
 
             if !args.no_display {

--- a/src/main.rs
+++ b/src/main.rs
@@ -328,6 +328,52 @@ fn main() -> Result<()> {
             }
         },
         None => {
+            // NOTE: use single, locked stdout handle to avoid interleaving
+            let stdout = stdout().lock();
+            // Path headers follow ripgrep conventions: shown in terminals,
+            // hidden when piped, with explicit overrides.
+            let show_path = if args.with_path {
+                true
+            } else if args.no_path {
+                false
+            } else {
+                stdout.is_terminal()
+            };
+            let mut writer = BufWriter::new(stdout);
+
+            // --depth without a query: sole positional argument is the file
+            if args.depth && args.query.is_some() && args.input.is_none() {
+                args.input = args.query.take().map(PathBuf::from);
+            }
+            // short circuit to only perform the depth computation
+            if args.depth && args.input.is_some() {
+                let format = detect_format(args.input.as_ref(), args.format);
+                let input_content = parse_input_content(args.input)?;
+                let json_string_owned = match format {
+                    Format::Auto | Format::Json => None,
+                    other => Some(input_content.to_json_string(other)?),
+                };
+                let json_str: &str = match &json_string_owned {
+                    Some(s) => s.as_str(),
+                    None => input_content
+                        .to_str()
+                        .context("File contents are not valid UTF-8")?,
+                };
+                let json: Value = serde_json::from_str(json_str)
+                    .with_context(|| format!("Failed to parse as {format}"))?;
+                if args.porcelain {
+                    writeln!(writer, "{}", depth(&json))?;
+                } else {
+                    writeln!(
+                        writer,
+                        "{} {}",
+                        "Depth:".bold().blue(),
+                        depth(&json)
+                    )?;
+                }
+                return Ok(());
+            }
+
             let raw_query = args.query.ok_or_else(|| {
                 anyhow::anyhow!("Query string required unless using subcommand")
             })?;
@@ -372,21 +418,6 @@ fn main() -> Result<()> {
                 QueryDFA::from_query(&query)
             };
             let results = dfa.find(&json);
-
-            // NOTE: use single, locked stdout handle to avoid interleaving
-            let stdout = stdout().lock();
-
-            // Path headers follow ripgrep conventions: shown in terminals,
-            // hidden when piped, with explicit overrides.
-            let show_path = if args.with_path {
-                true
-            } else if args.no_path {
-                false
-            } else {
-                stdout.is_terminal()
-            };
-
-            let mut writer = BufWriter::new(stdout);
 
             if args.count || args.depth {
                 args.no_display = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -310,6 +310,7 @@ fn detect_format(path: Option<&PathBuf>, explicit: Format) -> Format {
 /// This parses the command line arguments and executes the query. If the input
 /// is piped in, it reads from STDIN. The output is printed to STDOUT, with
 /// formatting determined by the command line arguments.
+#[expect(clippy::too_many_lines, reason = "Argument parsing combinations")]
 fn main() -> Result<()> {
     let mut args = Args::parse();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -305,6 +305,33 @@ fn detect_format(path: Option<&PathBuf>, explicit: Format) -> Format {
     }
 }
 
+/// Parses the input and invokes `f` with a borrowed [`Value`] to preserve zero-copy path for
+/// JSON/Auto `Format`s.
+fn with_json<F, T>(input: Option<PathBuf>, format: Format, f: F) -> Result<T>
+where
+    F: FnOnce(&Value) -> Result<T>,
+{
+    let input_content = parse_input_content(input)?;
+
+    // For JSON/Auto we borrow directly from the mmap/stdin buffer,
+    // preserving the zero-copy path that serde_json_borrow provides.
+    // For other formats, we convert to an owned JSON string first
+    // and then borrow from that.
+    let json_string_owned = match format {
+        Format::Json | Format::Auto => None,
+        other => Some(input_content.to_json_string(other)?),
+    };
+    let json_str: &str = match &json_string_owned {
+        Some(s) => s.as_str(),
+        None => input_content
+            .to_str()
+            .context("File contents are not valid UTF-8")?,
+    };
+    let json: Value = serde_json::from_str(json_str)
+        .with_context(|| format!("Failed to parse as {format}"))?;
+    f(&json)
+}
+
 /// Entry point for main binary.
 ///
 /// This parses the command line arguments and executes the query. If the input
@@ -348,29 +375,20 @@ fn main() -> Result<()> {
             // short circuit to only perform the depth computation
             if args.depth && args.input.is_some() {
                 let format = detect_format(args.input.as_ref(), args.format);
-                let input_content = parse_input_content(args.input)?;
-                let json_string_owned = match format {
-                    Format::Auto | Format::Json => None,
-                    other => Some(input_content.to_json_string(other)?),
-                };
-                let json_str: &str = match &json_string_owned {
-                    Some(s) => s.as_str(),
-                    None => input_content
-                        .to_str()
-                        .context("File contents are not valid UTF-8")?,
-                };
-                let json: Value = serde_json::from_str(json_str)
-                    .with_context(|| format!("Failed to parse as {format}"))?;
-                if args.porcelain {
-                    writeln!(writer, "{}", depth(&json))?;
-                } else {
-                    writeln!(
-                        writer,
-                        "{} {}",
-                        "Depth:".bold().blue(),
-                        depth(&json)
-                    )?;
-                }
+                with_json(args.input, format, |json| {
+                    if args.porcelain {
+                        writeln!(writer, "{}", depth(json))?;
+                    } else {
+                        writeln!(
+                            writer,
+                            "{} {}",
+                            "Depth:".bold().blue(),
+                            depth(json)
+                        )?;
+                    }
+                    Ok(())
+                })?;
+
                 return Ok(());
             }
 
@@ -393,75 +411,60 @@ fn main() -> Result<()> {
             };
 
             let format = detect_format(args.input.as_ref(), args.format);
-            let input_content = parse_input_content(args.input)?;
-
-            // For JSON/Auto we borrow directly from the mmap/stdin buffer,
-            // preserving the zero-copy path that serde_json_borrow provides.
-            // For other formats, we convert to an owned JSON string first
-            // and then borrow from that.
-            let json_string_owned = match format {
-                Format::Json | Format::Auto => None,
-                other => Some(input_content.to_json_string(other)?),
-            };
-            let json_str: &str = match &json_string_owned {
-                Some(s) => s.as_str(),
-                None => input_content
-                    .to_str()
-                    .context("File contents are not valid UTF-8")?,
-            };
-
-            let json: Value = serde_json::from_str(json_str)
-                .with_context(|| format!("Failed to parse as {format}"))?;
-            let dfa = if args.ignore_case {
-                QueryDFA::from_query_ignore_case(&query)
-            } else {
-                QueryDFA::from_query(&query)
-            };
-            let results = dfa.find(&json);
-
-            if args.count || args.depth {
-                args.no_display = true;
-            }
-
-            if args.count {
-                if args.porcelain {
-                    writeln!(writer, "{}", results.len())?;
+            with_json(args.input, format, |json| {
+                let dfa = if args.ignore_case {
+                    QueryDFA::from_query_ignore_case(&query)
                 } else {
-                    writeln!(
-                        writer,
-                        "{} {}",
-                        "Found matches:".bold().blue(),
-                        results.len()
-                    )
-                    .with_context(|| "Failed to write to stdout")?;
-                }
-            }
+                    QueryDFA::from_query(&query)
+                };
+                let results = dfa.find(json);
 
-            if args.depth {
-                if args.porcelain {
-                    writeln!(writer, "{}", depth(&json))?;
-                } else {
-                    writeln!(
-                        writer,
-                        "{} {}",
-                        "Depth:".bold().blue(),
-                        depth(&json)
-                    )?;
+                if args.count || args.depth {
+                    args.no_display = true;
                 }
-            }
 
-            if !args.no_display {
-                let pretty = !args.compact;
-                for result in &results {
-                    write_colored_result(
-                        &mut writer,
-                        result.value,
-                        &result.path,
-                        pretty,
-                        show_path,
-                    )?;
+                if args.count {
+                    if args.porcelain {
+                        writeln!(writer, "{}", results.len())?;
+                    } else {
+                        writeln!(
+                            writer,
+                            "{} {}",
+                            "Found matches:".bold().blue(),
+                            results.len()
+                        )
+                        .with_context(|| "Failed to write to stdout")?;
+                    }
                 }
-            }
+
+                if args.depth {
+                    if args.porcelain {
+                        writeln!(writer, "{}", depth(json))?;
+                    } else {
+                        writeln!(
+                            writer,
+                            "{} {}",
+                            "Depth:".bold().blue(),
+                            depth(json)
+                        )?;
+                    }
+                }
+
+                if !args.no_display {
+                    let pretty = !args.compact;
+                    for result in &results {
+                        write_colored_result(
+                            &mut writer,
+                            result.value,
+                            &result.path,
+                            pretty,
+                            show_path,
+                        )?;
+                    }
+                }
+
+                Ok(())
+            })?;
 
             match writer.flush() {
                 Ok(()) => {}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -559,4 +559,43 @@ mod tests {
         let tmp = temp_file_with(".msgpack", b"\x85");
         run_main(&["age", tmp.path().to_str().expect("temp path")]).failure();
     }
+
+    #[test]
+    fn count_suppresses_match_output() {
+        let assert = run_main(&["age", SIMPLE_JSON_FILEPATH, "--count"])
+            .success()
+            .code(0);
+        let output = String::from_utf8(assert.get_output().stdout.clone())
+            .expect("Invalid UTF-8 output");
+        assert!(!output.contains("32"), "--count should suppress match values");
+    }
+
+    #[test]
+    fn depth_outputs_labeled_number() {
+        let assert =
+            run_main(&["", SIMPLE_JSON_FILEPATH, "--depth"]).success().code(0);
+        let output = String::from_utf8(assert.get_output().stdout.clone())
+            .expect("Invalid UTF-8 output");
+        assert!(
+            output.contains("Depth:") && output.contains('3'),
+            "Expected 'Depth: 3', got: {output:?}"
+        );
+    }
+
+    #[test]
+    fn depth_porcelain_outputs_bare_number() {
+        let assert =
+            run_main(&["", SIMPLE_JSON_FILEPATH, "--depth", "--porcelain"])
+                .success()
+                .code(0);
+        let output = String::from_utf8(assert.get_output().stdout.clone())
+            .expect("Invalid UTF-8 output");
+        assert_eq!(output.trim(), "3");
+    }
+
+    #[test]
+    fn count_and_depth_are_mutually_exclusive() {
+        run_main(&["age", SIMPLE_JSON_FILEPATH, "--count", "--depth"])
+            .failure();
+    }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -571,9 +571,33 @@ mod tests {
     }
 
     #[test]
-    fn depth_outputs_labeled_number() {
+    fn count_outputs_labeled_number() {
+        let assert = run_main(&["name", SIMPLE_JSON_FILEPATH, "--count"])
+            .success()
+            .code(0);
+        let output = String::from_utf8(assert.get_output().stdout.clone())
+            .expect("Invalid UTF-8 output");
+        assert!(
+            output.contains("Found matches:") && output.contains('1'),
+            "Expected 'Found matches: 1', got: {output:?}"
+        );
+    }
+
+    #[test]
+    fn count_porcelain_outputs_bare_number() {
         let assert =
-            run_main(&["", SIMPLE_JSON_FILEPATH, "--depth"]).success().code(0);
+            run_main(&["name", SIMPLE_JSON_FILEPATH, "--count", "--porcelain"])
+                .success()
+                .code(0);
+        let output = String::from_utf8(assert.get_output().stdout.clone())
+            .expect("Invalid UTF-8 output");
+        assert_eq!(output.trim(), "1");
+    }
+
+    #[test]
+    fn depth_outputs_labeled_number_without_query() {
+        let assert =
+            run_main(&[SIMPLE_JSON_FILEPATH, "--depth"]).success().code(0);
         let output = String::from_utf8(assert.get_output().stdout.clone())
             .expect("Invalid UTF-8 output");
         assert!(
@@ -583,9 +607,20 @@ mod tests {
     }
 
     #[test]
+    fn depth_suppresses_match_output() {
+        let assert = run_main(&["age", SIMPLE_JSON_FILEPATH, "--depth"])
+            .success()
+            .code(0);
+        let output = String::from_utf8(assert.get_output().stdout.clone())
+            .expect("Invalid UTF-8 output");
+        assert!(!output.contains("32"), "--depth should suppress match values");
+        assert!(output.contains('3'), "--depth should still output depth");
+    }
+
+    #[test]
     fn depth_porcelain_outputs_bare_number() {
         let assert =
-            run_main(&["", SIMPLE_JSON_FILEPATH, "--depth", "--porcelain"])
+            run_main(&[SIMPLE_JSON_FILEPATH, "--depth", "--porcelain"])
                 .success()
                 .code(0);
         let output = String::from_utf8(assert.get_output().stdout.clone())


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
  
### Adds 
  
- `--porcelain` flag &rarr; outputs explicit machine-readable output (mimics `git` convention)

### Changes 

- make `--count`/ `--depth` mutually exclusive
  - Previously, either could be used in combination, but with the addition of `--porcelain`, which strips the "Found matches"/"Depth" prefixes from the output, the bare count/depth results would be indistinguishable
  - Explicitly makes these options mutually exclusive via `clap`'s `conflicts_with` attribute

- `--depth` option now does not require a query string, if no query string is provided, then the input must be the sole positional argument and is treated as such. No user-facing changes, old invocation still works.

- `--count`/ `--depth` now imply `--no-display` &rarr; these options are solely for matches and document analysis, do not need display of the results, especially for `--depth`, which now doe not need a query string.

> [!NOTE]
> No library changes.

### Breaking

BREAKING CHANGE: `--count`/ `--depth` are now **mutually exclusive**

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

N/A.

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Testing (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

- 7 new CLI integration tests in `cli.rs` testing new behavior.
- All existing tests pass.
