### PR TITLE
perf(cli): parse JSONL per line instead of building a synthetic array string

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -153,27 +153,6 @@ impl Input {
 
     fn to_json_string(&self, format: Format) -> Result<String> {
         match format {
-            Format::Jsonl => {
-                let text = self.to_str().map_err(|_| {
-                    anyhow::anyhow!("JSONL input is not valid UTF-8")
-                })?;
-                let mut buf = String::from("[");
-                let mut first = true;
-                for line in text.lines() {
-                    let line = line.trim();
-                    if line.is_empty() {
-                        continue;
-                    }
-                    if !first {
-                        buf.push(',');
-                    }
-                    buf.push_str(line);
-                    first = false;
-                }
-                buf.push(']');
-                Ok(buf)
-            }
-
             // YAML
             #[cfg(feature = "yaml")]
             Format::Yaml => {
@@ -240,9 +219,11 @@ impl Input {
             }
 
             // Unreachable, someone made an oopsie
-            Format::Auto | Format::Json => {
+            // (JSONL is parsed per line in `parse_jsonl`, borrowing from the
+            // input buffer, so it never goes through this owned-string path.)
+            Format::Auto | Format::Json | Format::Jsonl => {
                 unreachable!(
-                    "to_json_string called with Auto or Json, not needed"
+                    "to_json_string called with Auto, Json, or Jsonl, not needed"
                 )
             }
         }
@@ -357,8 +338,29 @@ fn detect_format(path: Option<&PathBuf>, explicit: Format) -> Format {
     }
 }
 
+/// Parse JSONL/NDJSON input line by line into a single top-level array,
+/// borrowing each record directly from the input buffer.
+///
+/// Compared to concatenating all lines into a synthetic `[...]` JSON string
+/// and re-parsing it, this avoids a second full-input-sized allocation and
+/// reports parse errors with the actual line number of the offending record.
+fn parse_jsonl(text: &str) -> Result<Value<'_>> {
+    let mut records = Vec::new();
+    for (idx, line) in text.lines().enumerate() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let record: Value = serde_json::from_str(line).with_context(|| {
+            format!("Failed to parse JSONL line {}", idx + 1)
+        })?;
+        records.push(record);
+    }
+    Ok(Value::Array(records))
+}
+
 /// Parses the input and invokes `f` with a borrowed [`Value`] to preserve zero-copy path for
-/// JSON/Auto `Format`s.
+/// JSON/Auto and JSONL `Format`s.
 fn with_json<F, T>(input: Option<PathBuf>, format: Format, f: F) -> Result<T>
 where
     F: FnOnce(&Value) -> Result<T>,
@@ -366,20 +368,32 @@ where
     let input_content = parse_input_content(input)?;
 
     // For JSON/Auto we borrow directly from the mmap/stdin buffer,
-    // preserving the zero-copy path that serde_json_borrow provides.
-    // For other formats, we convert to an owned JSON string first
-    // and then borrow from that.
-    let json_string_owned = match format {
-        Format::Json | Format::Auto => None,
-        other => Some(input_content.to_json_string(other)?),
-    };
-    let json_str: &str = match &json_string_owned {
-        Some(s) => s.as_str(),
-        None => input_content.to_str().context("Input is not valid UTF-8")?,
-    };
-    let json: Value = serde_json::from_str(json_str)
-        .with_context(|| format!("Failed to parse as {format}"))?;
-    f(&json)
+    // preserving the zero-copy path that serde_json_borrow provides. JSONL
+    // is parsed per line, likewise borrowing from the input buffer. For
+    // other formats, we convert to an owned JSON string first and then
+    // borrow from that.
+    match format {
+        Format::Json | Format::Auto => {
+            let json_str =
+                input_content.to_str().context("Input is not valid UTF-8")?;
+            let json: Value = serde_json::from_str(json_str)
+                .with_context(|| format!("Failed to parse as {format}"))?;
+            f(&json)
+        }
+        Format::Jsonl => {
+            let text = input_content.to_str().map_err(|_| {
+                anyhow::anyhow!("JSONL input is not valid UTF-8")
+            })?;
+            let json = parse_jsonl(text)?;
+            f(&json)
+        }
+        other => {
+            let json_string_owned = input_content.to_json_string(other)?;
+            let json: Value = serde_json::from_str(&json_string_owned)
+                .with_context(|| format!("Failed to parse as {format}"))?;
+            f(&json)
+        }
+    }
 }
 
 /// Entry point for main binary.

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -491,6 +491,74 @@ mod tests {
     }
 
     #[test]
+    fn jsonl_parse_error_reports_line_number() {
+        // Line 2 is malformed; the error must point at the user's actual
+        // line, not a position inside an internal buffer.
+        let jsonl_content = "{\"id\": 1}\n{\"id\": oops}\n{\"id\": 3}\n";
+        let mut cmd =
+            Command::cargo_bin("jg").expect("Failed to find main binary");
+        let assert = cmd
+            .args(["-f", "jsonl", "[*].id"])
+            .write_stdin(jsonl_content)
+            .assert()
+            .failure();
+        let stderr = String::from_utf8(assert.get_output().stderr.clone())
+            .expect("Invalid UTF-8 output");
+        assert!(
+            stderr.contains("Failed to parse JSONL line 2"),
+            "JSONL parse error should name line 2, got: {stderr:?}"
+        );
+    }
+
+    #[test]
+    fn jsonl_crlf_line_endings() {
+        let jsonl_content = "{\"id\": 1}\r\n{\"id\": 2}\r\n";
+        let mut cmd =
+            Command::cargo_bin("jg").expect("Failed to find main binary");
+        let assert = cmd
+            .args([
+                "-f",
+                "jsonl",
+                "[*].id",
+                "--count",
+                "--no-display",
+                "--porcelain",
+            ])
+            .write_stdin(jsonl_content)
+            .assert()
+            .success();
+        let output = String::from_utf8(assert.get_output().stdout.clone())
+            .expect("Invalid UTF-8 output");
+        assert_eq!(
+            output.trim(),
+            "2",
+            "CRLF-terminated JSONL records should parse"
+        );
+    }
+
+    #[test]
+    fn jsonl_blank_lines_are_skipped() {
+        let jsonl_content = "{\"id\": 1}\n\n   \n{\"id\": 2}\n";
+        let mut cmd =
+            Command::cargo_bin("jg").expect("Failed to find main binary");
+        let assert = cmd
+            .args([
+                "-f",
+                "jsonl",
+                "[*].id",
+                "--count",
+                "--no-display",
+                "--porcelain",
+            ])
+            .write_stdin(jsonl_content)
+            .assert()
+            .success();
+        let output = String::from_utf8(assert.get_output().stdout.clone())
+            .expect("Invalid UTF-8 output");
+        assert_eq!(output.trim(), "2", "blank JSONL lines should be skipped");
+    }
+
+    #[test]
     fn jsonl_stdin_with_format_flag() {
         let jsonl_content =
             std::fs::read_to_string(SIMPLE_JSONL_FILEPATH).expect("read jsonl");


### PR DESCRIPTION
JSONL/NDJSON input was concatenated into one giant owned "[...]" JSON
string and re-parsed, costing a second full-input-sized allocation and
reporting parse-error positions inside the synthetic buffer rather than
the user's file.

Parse each line directly into a borrowed Value (zero-copy from the
mmap/stdin buffer, same as plain JSON input) and wrap the records in a
top-level Value::Array. Parse errors now name the actual input line
("Failed to parse JSONL line 2").

Measurements on a 54 MB, 120k-record JSONL file (release build):

  peak RSS   464 -> 391 MB  (-16%)
  runtime    323 -> 296 ms  (~9% faster)

Match output verified byte-identical (sha256). New CLI tests: parse
error reports the offending line number, blank/whitespace lines are
skipped, CRLF line endings parse.


---

*This PR is one of a series from a full-repo review (each branch is independent off `main`). Where PRs touch the same files (`CHANGELOG.md`, `src/query/dfa.rs`, `src/main.rs`), conflicts are trivial - mostly CHANGELOG section concatenation - and I'm happy to rebase whichever land later.*
