### PR TITLE
perf(output): skip unused path strings and stop formatting on broken pipe

### DIFF
--- a/examples/parse_and_query.rs
+++ b/examples/parse_and_query.rs
@@ -33,7 +33,9 @@ fn main() -> anyhow::Result<()> {
     let results = jsongrep::grep(&json, "users[*].name").expect("valid query");
 
     for result in &results {
-        write_colored_result(
+        // `write_colored_result` returns Ok(false) when the output pipe has
+        // been closed (e.g. piping into `head`), so callers can stop early.
+        if !write_colored_result(
             &mut writer,
             result.value,
             &result.path,
@@ -42,7 +44,9 @@ fn main() -> anyhow::Result<()> {
                 show_path: true,
                 ..Default::default()
             },
-        )?;
+        )? {
+            break;
+        }
     }
     writer.write_all(b"\n")?;
 
@@ -63,7 +67,7 @@ fn main() -> anyhow::Result<()> {
         let json: Value = serde_json::from_str(doc).expect("valid JSON");
         let results = dfa.find(&json);
         for result in &results {
-            write_colored_result(
+            if !write_colored_result(
                 &mut writer,
                 result.value,
                 &result.path,
@@ -72,7 +76,9 @@ fn main() -> anyhow::Result<()> {
                     show_path: true,
                     ..Default::default()
                 },
-            )?;
+            )? {
+                break;
+            }
         }
     }
     writer.write_all(b"\n")?;
@@ -89,7 +95,7 @@ fn main() -> anyhow::Result<()> {
 
     writer.write_all(b"users[*].* results (via AST):\n")?;
     for result in &results {
-        write_colored_result(
+        if !write_colored_result(
             &mut writer,
             result.value,
             &result.path,
@@ -98,7 +104,9 @@ fn main() -> anyhow::Result<()> {
                 show_path: true,
                 ..Default::default()
             },
-        )?;
+        )? {
+            break;
+        }
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -510,7 +510,9 @@ fn main() -> Result<()> {
                 if !args.no_display {
                     let pretty = !args.compact;
                     for result in &results {
-                        write_colored_result(
+                        // Stop formatting once the downstream consumer is
+                        // gone (e.g. `jg ... | head -1`).
+                        if !write_colored_result(
                             &mut writer,
                             result.value,
                             &result.path,
@@ -519,7 +521,9 @@ fn main() -> Result<()> {
                                 show_path,
                                 raw: args.raw_output,
                             },
-                        )?;
+                        )? {
+                            break;
+                        }
                     }
                 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -39,8 +39,11 @@ pub struct WriteOptions {
 }
 
 /// Write a single query result (path header + colorized JSON value) to `writer`.
-/// Silently returns `Ok(())` on broken pipe so that piping to tools like
-/// `less` or `head` exits cleanly.
+///
+/// Returns `Ok(true)` when the result was written and the caller may keep
+/// writing further results, and `Ok(false)` on a broken pipe (the downstream
+/// consumer, e.g. `head` or `less`, has gone away), so the caller can stop
+/// formatting the remaining results instead of writing into a dead pipe.
 ///
 /// When `raw` is set, a matched value that is a string is written without
 /// JSON quotes or escaping (like `jq -r`), so shell pipelines get the bare
@@ -49,22 +52,26 @@ pub struct WriteOptions {
 ///
 /// # Errors
 ///
-/// Returns an error if writing to `writer` fails.
+/// Returns an error if writing to `writer` fails for any reason other than a
+/// broken pipe.
 pub fn write_colored_result<W: Write>(
     writer: &mut W,
     value: &Value,
     path: &[PathType],
     options: &WriteOptions,
-) -> anyhow::Result<()> {
-    let path = path
-        .iter()
-        .map(std::string::ToString::to_string)
-        .collect::<Vec<_>>()
-        .join(".");
-
+) -> anyhow::Result<bool> {
     let result = (|| -> io::Result<()> {
         if options.show_path && !path.is_empty() {
-            writeln!(writer, "{}:", path.bold().magenta())?;
+            // Only pay for building the joined path string when it is
+            // actually shown.
+            let mut header = String::new();
+            for (i, part) in path.iter().enumerate() {
+                if i > 0 {
+                    header.push('.');
+                }
+                header.push_str(&part.to_string());
+            }
+            writeln!(writer, "{}:", header.bold().magenta())?;
         }
         if options.raw
             && let Value::Str(s) = value
@@ -81,8 +88,8 @@ pub fn write_colored_result<W: Write>(
     })();
 
     match result {
-        Ok(()) => Ok(()),
-        Err(err) if err.kind() == ErrorKind::BrokenPipe => Ok(()),
+        Ok(()) => Ok(true),
+        Err(err) if err.kind() == ErrorKind::BrokenPipe => Ok(false),
         Err(err) => Err(err).context("write colorized JSON to stdout"),
     }
 }
@@ -128,8 +135,8 @@ fn write_colored_json<W: Write>(
         }
         Value::Object(obj) => {
             write!(writer, "{{")?;
-            let entries: Vec<_> = obj.iter().collect();
-            for (i, (key, val)) in entries.iter().enumerate() {
+            let len = obj.len();
+            for (i, (key, val)) in obj.iter().enumerate() {
                 if pretty {
                     writeln!(writer)?;
                     write!(writer, "{:width$}", "", width = next_indent)?;
@@ -144,15 +151,76 @@ fn write_colored_json<W: Write>(
                     write!(writer, ":")?;
                 }
                 write_colored_json(writer, val, next_indent, pretty)?;
-                if i < entries.len() - 1 {
+                if i < len - 1 {
                     write!(writer, ",")?;
                 }
             }
-            if pretty && !entries.is_empty() {
+            if pretty && len > 0 {
                 writeln!(writer)?;
                 write!(writer, "{:width$}", "", width = indent)?;
             }
             write!(writer, "}}")
         }
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "Unit testing.")]
+mod tests {
+    use super::*;
+
+    /// A writer that always fails with the given [`ErrorKind`].
+    struct FailingWriter(ErrorKind);
+
+    impl Write for FailingWriter {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            Err(io::Error::from(self.0))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Err(io::Error::from(self.0))
+        }
+    }
+
+    #[test]
+    fn write_colored_result_returns_true_on_success() {
+        let value: Value = serde_json::from_str("{\"a\": 1}").unwrap();
+        let mut out = Vec::new();
+        let keep_going = write_colored_result(
+            &mut out,
+            &value,
+            &[],
+            &WriteOptions { pretty: true, ..Default::default() },
+        )
+        .unwrap();
+        assert!(keep_going);
+        assert!(!out.is_empty());
+    }
+
+    #[test]
+    fn write_colored_result_signals_stop_on_broken_pipe() {
+        let value: Value = serde_json::from_str("{\"a\": 1}").unwrap();
+        let mut broken = FailingWriter(ErrorKind::BrokenPipe);
+        let keep_going = write_colored_result(
+            &mut broken,
+            &value,
+            &[],
+            &WriteOptions { pretty: true, ..Default::default() },
+        )
+        .unwrap();
+        assert!(!keep_going, "broken pipe should signal the caller to stop");
+    }
+
+    #[test]
+    fn write_colored_result_propagates_other_errors() {
+        let value: Value = serde_json::from_str("{\"a\": 1}").unwrap();
+        let mut failing = FailingWriter(ErrorKind::PermissionDenied);
+        let result = write_colored_result(
+            &mut failing,
+            &value,
+            &[],
+            &WriteOptions { pretty: true, ..Default::default() },
+        );
+        assert!(result.is_err(), "non-pipe IO errors should propagate");
     }
 }


### PR DESCRIPTION
Two output-path fixes:

- write_colored_result built the dotted path header (a Vec<String>
  collect + join) for every result even when show_path was false (the
  default whenever output is piped). Build it only when it is shown.
  The object arm of write_colored_json also collected entries into a
  Vec just to know the length; use obj.len() directly.

- A broken pipe was swallowed per-result, so `jg ... | head -1` kept
  colorizing and formatting every remaining match into a dead pipe.
  write_colored_result now returns Ok(false) on BrokenPipe and the
  display loop stops. (Full early-exit during traversal is a separate,
  larger change - this only stops the formatting.)

Note: write_colored_result changes signature (anyhow::Result<()> ->
anyhow::Result<bool>), so this needs a 0.10.0 release.

Benchmarks (hyperfine, 55 MB JSON, 120k matches, release):

  jg --with-path q large.json | head -1    417 -> 311 ms  (-25%)
  jg q large.json > /dev/null (piped)      358 -> 323 ms  (-10%)

Output verified byte-identical (sha256). New unit tests cover the
stop-on-broken-pipe contract and error propagation for other IO errors.


---

*This PR is one of a series from a full-repo review (each branch is independent off `main`). Where PRs touch the same files (`CHANGELOG.md`, `src/query/dfa.rs`, `src/main.rs`), conflicts are trivial - mostly CHANGELOG section concatenation - and I'm happy to rebase whichever land later.*
