### PR TITLE
perf(dfa): visitor-based traversal with early exit, find_limited, -m/--max-count

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ Options:
       --porcelain        Machine-readable output: strip labels and colors (useful for piping)
   -n, --no-display       Do not display matched JSON values
   -F, --fixed-string     Treat the query as a literal field name and search at any depth
+  -m, --max-count <NUM>  Stop searching after NUM matches
       --with-path        Always print the path header, even when output is piped
       --no-path          Never print the path header, even in a terminal
   -f, --format <FORMAT>  Input format (auto-detects from file extension if omitted) [default: auto] [possible values: auto, json, jsonl, yaml, toml, cbor, msgpack]

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,6 +73,13 @@ struct Args {
     /// Searches for the field at any depth, equivalent to `(* | [*])*."<query>"`.
     #[arg(short = 'F', long, action = ArgAction::SetTrue)]
     fixed_string: bool,
+    /// Stop searching after NUM matches.
+    ///
+    /// The document traversal terminates as soon as the limit is reached,
+    /// so `--max-count 1` on a large document only pays for the work up to
+    /// the first match (like grep's `-m`).
+    #[arg(short = 'm', long, value_name = "NUM", conflicts_with = "depth")]
+    max_count: Option<usize>,
     /// Always print the path header, even when output is piped.
     #[arg(long, action = ArgAction::SetTrue, conflicts_with = "no_path")]
     with_path: bool,
@@ -474,7 +481,10 @@ fn main() -> Result<()> {
                 } else {
                     QueryDFA::from_query_bounded(&query, DEFAULT_MAX_DFA_STATES)
                 }?;
-                let results = dfa.find(json);
+                let results = args.max_count.map_or_else(
+                    || dfa.find(json),
+                    |limit| dfa.find_limited(json, limit),
+                );
 
                 if args.count || args.depth {
                     args.no_display = true;

--- a/src/query/dfa.rs
+++ b/src/query/dfa.rs
@@ -20,6 +20,7 @@ use serde_json_borrow::Value;
 use std::{
     collections::{HashMap, VecDeque},
     fmt::Display,
+    ops::ControlFlow,
     rc::Rc,
 };
 
@@ -378,6 +379,80 @@ impl QueryDFA {
     #[must_use]
     pub fn find<'a>(&self, json: &'a Value<'a>) -> Vec<JSONPointer<'a>> {
         DFAQueryEngine::find_with_dfa(json, self)
+    }
+
+    /// Execute this compiled query, returning at most `limit` matches in
+    /// document order.
+    ///
+    /// The traversal stops as soon as the limit is reached, so
+    /// `find_limited(json, 1)` costs O(work until the first match) rather
+    /// than a full document walk.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use jsongrep::{Value, query::QueryDFA};
+    ///
+    /// let json: Value =
+    ///     serde_json::from_str(r#"{"a": 1, "b": 2, "c": 3}"#).unwrap();
+    /// let query = QueryDFA::from_query_str("*").unwrap();
+    /// assert_eq!(query.find_limited(&json, 2).len(), 2);
+    /// ```
+    #[must_use]
+    pub fn find_limited<'a>(
+        &self,
+        json: &'a Value<'a>,
+        limit: usize,
+    ) -> Vec<JSONPointer<'a>> {
+        if limit == 0 {
+            return Vec::new();
+        }
+        let mut results = Vec::new();
+        let _: ControlFlow<()> =
+            DFAQueryEngine::visit_with_dfa(json, self, |ptr| {
+                results.push(ptr);
+                if results.len() >= limit {
+                    ControlFlow::Break(())
+                } else {
+                    ControlFlow::Continue(())
+                }
+            });
+        results
+    }
+
+    /// Execute this compiled query, invoking `visit` for each match in
+    /// document order. Return [`ControlFlow::Break`] from the visitor to
+    /// stop the search early; the break value is returned to the caller
+    /// (`ControlFlow::Continue(())` means the whole document was searched).
+    ///
+    /// This is the zero-materialization primitive: existence checks and
+    /// streaming consumers avoid collecting matches into a `Vec` entirely.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::ops::ControlFlow;
+    /// use jsongrep::{Value, query::QueryDFA};
+    ///
+    /// let json: Value =
+    ///     serde_json::from_str(r#"{"a": 1, "b": 2}"#).unwrap();
+    /// let query = QueryDFA::from_query_str("*").unwrap();
+    ///
+    /// // Existence check: stop at the first match.
+    /// let found = query
+    ///     .for_each_match(&json, |_| ControlFlow::Break(()))
+    ///     .is_break();
+    /// assert!(found);
+    /// ```
+    pub fn for_each_match<'a, B, F>(
+        &self,
+        json: &'a Value<'a>,
+        visit: F,
+    ) -> ControlFlow<B>
+    where
+        F: FnMut(JSONPointer<'a>) -> ControlFlow<B>,
+    {
+        DFAQueryEngine::visit_with_dfa(json, self, visit)
     }
 
     /// Check if a given state is accepting/final.
@@ -820,21 +895,27 @@ impl DFABuilder {
 pub struct DFAQueryEngine;
 
 impl DFAQueryEngine {
-    /// Performs a depth-first search over the JSON document AST, accumulating
-    /// results as it traverses and finds final states.
-    fn traverse_json<'a>(
+    /// Performs a depth-first search over the JSON document AST, invoking the
+    /// visitor for each match. The visitor returns [`ControlFlow::Break`] to
+    /// stop the traversal early (e.g. after enough matches have been seen);
+    /// the break propagates straight up through the recursion, so an early
+    /// stop costs no further document work.
+    fn traverse_json<'a, B, F>(
         dfa: &QueryDFA,
         current_state: usize,
         path: &mut Vec<PathType>,
         value: &'a Value<'a>,
-        results: &mut Vec<JSONPointer<'a>>,
-    ) {
+        visit: &mut F,
+    ) -> ControlFlow<B>
+    where
+        F: FnMut(JSONPointer<'a>) -> ControlFlow<B>,
+    {
         // Check if current state is accepting
         if dfa.is_accepting_state(current_state) {
-            results.push(JSONPointer {
+            visit(JSONPointer {
                 path: path.clone(), // clone path only for result
                 value,
-            });
+            })?;
         }
 
         match value {
@@ -852,12 +933,13 @@ impl DFAQueryEngine {
                         path.push(PathType::Field(key_rc));
 
                         // Recurse on the extended path
-                        Self::traverse_json(
-                            dfa, next_state, path, val, results,
+                        let flow = Self::traverse_json(
+                            dfa, next_state, path, val, visit,
                         );
 
                         // Backtrack by removing what we just added
                         path.pop();
+                        flow?;
                     }
                 }
             }
@@ -873,12 +955,13 @@ impl DFAQueryEngine {
                             path.push(PathType::Index(idx));
 
                             // Recurse on the extended path
-                            Self::traverse_json(
-                                dfa, next_state, path, val, results,
+                            let flow = Self::traverse_json(
+                                dfa, next_state, path, val, visit,
                             );
 
                             // Backtrack
                             path.pop();
+                            flow?;
                         }
                     }
                     // If get_index_symbol_id returns None, skip this index (no valid transition)
@@ -888,6 +971,8 @@ impl DFAQueryEngine {
             Value::Null | Value::Bool(_) | Value::Number(_) | Value::Str(_) => {
             }
         }
+
+        ControlFlow::Continue(())
     }
 }
 
@@ -902,15 +987,32 @@ impl DFAQueryEngine {
         dfa: &QueryDFA,
     ) -> Vec<JSONPointer<'a>> {
         let mut results = Vec::new();
-        let mut path = Vec::new();
-        Self::traverse_json(
-            dfa,
-            dfa.start_state,
-            &mut path,
-            json,
-            &mut results,
-        );
+        let _: ControlFlow<()> = Self::visit_with_dfa(json, dfa, |ptr| {
+            results.push(ptr);
+            ControlFlow::Continue(())
+        });
         results
+    }
+
+    /// Search a JSON document using a pre-compiled [`QueryDFA`], invoking
+    /// `visit` for each match in document order.
+    ///
+    /// The visitor returns [`ControlFlow::Break`] to stop the search early;
+    /// the remainder of the document is then not traversed and the break
+    /// value is returned. This is the primitive behind [`QueryDFA::find`]
+    /// and [`QueryDFA::find_limited`], and the right entry point for
+    /// existence checks or streaming consumption where materializing every
+    /// match up front is wasteful.
+    pub fn visit_with_dfa<'a, B, F>(
+        json: &'a Value<'a>,
+        dfa: &QueryDFA,
+        mut f: F,
+    ) -> ControlFlow<B>
+    where
+        F: FnMut(JSONPointer<'a>) -> ControlFlow<B>,
+    {
+        let mut path = Vec::new();
+        Self::traverse_json(dfa, dfa.start_state, &mut path, json, &mut f)
     }
 }
 
@@ -2017,5 +2119,66 @@ mod tests {
 
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].value, &Value::Number(2u64.into()));
+    }
+
+    // ==============================================================================
+    // Early exit / bounded search
+    // ==============================================================================
+
+    #[test]
+    fn find_limited_returns_prefix_of_find() {
+        let input = r#"{ "users": [
+            {"name": "a"}, {"name": "b"}, {"name": "c"}, {"name": "d"}
+        ]}"#;
+        let json: Value = serde_json::from_str(input).expect("hardcoded json");
+        let dfa =
+            QueryDFA::from_query_str("users.[*].name").expect("valid query");
+
+        let all = dfa.find(&json);
+        assert_eq!(all.len(), 4);
+
+        for limit in 0..=5 {
+            let limited = dfa.find_limited(&json, limit);
+            assert_eq!(limited.len(), limit.min(4), "limit {limit}");
+            // Same matches, same document order.
+            for (l, a) in limited.iter().zip(&all) {
+                assert_eq!(l.path, a.path);
+                assert_eq!(l.value, a.value);
+            }
+        }
+    }
+
+    #[test]
+    fn for_each_match_break_stops_traversal() {
+        let input = r#"{ "users": [
+            {"name": "a"}, {"name": "b"}, {"name": "c"}
+        ]}"#;
+        let json: Value = serde_json::from_str(input).expect("hardcoded json");
+        let dfa =
+            QueryDFA::from_query_str("users.[*].name").expect("valid query");
+
+        // The visitor must not be invoked again after it breaks.
+        let mut calls = 0;
+        let flow = dfa.for_each_match(&json, |_| {
+            calls += 1;
+            ControlFlow::Break(())
+        });
+        assert_eq!(calls, 1, "visitor must not be called after Break");
+        assert!(flow.is_break(), "early stop must surface to the caller");
+    }
+
+    #[test]
+    fn for_each_match_continue_visits_all() {
+        let input = r#"{ "a": 1, "b": 2, "c": 3 }"#;
+        let json: Value = serde_json::from_str(input).expect("hardcoded json");
+        let dfa = QueryDFA::from_query_str("*").expect("valid query");
+
+        let mut calls = 0;
+        let flow: ControlFlow<()> = dfa.for_each_match(&json, |_| {
+            calls += 1;
+            ControlFlow::Continue(())
+        });
+        assert_eq!(calls, 3);
+        assert!(flow.is_continue(), "full search must report Continue");
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -491,6 +491,56 @@ mod tests {
     }
 
     #[test]
+    fn max_count_limits_matches() {
+        let output = run_main(&[
+            "[*].id",
+            SIMPLE_JSONL_FILEPATH,
+            "--max-count",
+            "2",
+            "--count",
+            "--no-display",
+            "--porcelain",
+        ])
+        .success()
+        .code(0)
+        .get_output()
+        .stdout
+        .clone();
+        let output_str =
+            String::from_utf8(output).expect("Invalid UTF-8 output");
+        assert_eq!(
+            output_str.trim(),
+            "2",
+            "--max-count 2 should cap matches at 2"
+        );
+    }
+
+    #[test]
+    fn max_count_larger_than_matches_returns_all() {
+        let output = run_main(&[
+            "[*].id",
+            SIMPLE_JSONL_FILEPATH,
+            "-m",
+            "100",
+            "--count",
+            "--no-display",
+            "--porcelain",
+        ])
+        .success()
+        .code(0)
+        .get_output()
+        .stdout
+        .clone();
+        let output_str =
+            String::from_utf8(output).expect("Invalid UTF-8 output");
+        assert_eq!(
+            output_str.trim(),
+            "3",
+            "-m larger than the match count should return all matches"
+        );
+    }
+
+    #[test]
     fn jsonl_stdin_with_format_flag() {
         let jsonl_content =
             std::fs::read_to_string(SIMPLE_JSONL_FILEPATH).expect("read jsonl");


### PR DESCRIPTION
traverse_json is now driven by a visitor returning ControlFlow: Break
propagates straight up the recursion (with balanced path backtracking),
so stopping after N matches costs no further document work. Previously
find() always materialized every match, so even "does any match exist?"
paid for a full walk.

New public API:
- QueryDFA::find_limited(json, limit): at most `limit` matches in
  document order, stopping the walk at the limit.
- QueryDFA::for_each_match(json, visitor) -> ControlFlow<B>: the
  zero-materialization primitive; generic break payload, returns the
  visitor's break value (Continue means the whole document was walked).
- DFAQueryEngine::visit_with_dfa: same, for pre-compiled DFA + engine
  callers. find()/find_with_dfa are reimplemented on the visitor with
  unchanged behavior.

CLI gains -m/--max-count NUM (grep's -m): stop searching after NUM
matches. Conflicts with --depth (which never runs a query).

Benchmarks (hyperfine, release):

  55 MB JSON, users[*].profile.settings.theme:
    full search --count   309 ms  ->  -m 1  230 ms  (1.35x)
  190 MB citylots.json, (* | [*])*.MAPBLKLOT:
    full search --count   935 ms  ->  -m 1  645 ms  (1.45x)

Remaining time is JSON parsing, which now dominates: the search itself
is O(work to the first match). New unit tests: find_limited returns an
exact prefix of find() for limits 0..=N+1, the visitor is never called
after Break, and break/continue surface to the caller. New CLI tests
for -m capping and over-limit behavior.


---

*This PR is one of a series from a full-repo review (each branch is independent off `main`). Where PRs touch the same files (`CHANGELOG.md`, `src/query/dfa.rs`, `src/main.rs`), conflicts are trivial - mostly CHANGELOG section concatenation - and I'm happy to rebase whichever land later.*
