### PR TITLE
chore(deps): drop unused regex, log, env_logger, clap-verbosity-flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,16 +222,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap-verbosity-flag"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeab6a5cdfc795a05538422012f20a5496f050223c91be4e5420bfd13c641fb1"
-dependencies = [
- "clap",
- "log",
-]
-
-[[package]]
 name = "clap_builder"
 version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,29 +415,6 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "env_filter"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
-]
 
 [[package]]
 name = "equivalent"
@@ -650,30 +617,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "jmespath"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,12 +668,10 @@ dependencies = [
  "assert_cmd",
  "ciborium",
  "clap",
- "clap-verbosity-flag",
  "clap_complete",
  "clap_mangen",
  "colored",
  "criterion",
- "env_logger",
  "jaq-core",
  "jaq-json",
  "jaq-std",
@@ -738,11 +679,9 @@ dependencies = [
  "jql-parser",
  "jql-runner",
  "jsonpath-rust",
- "log",
  "memmap2",
  "pest",
  "pest_derive",
- "regex",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -917,21 +856,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
-]
-
-[[package]]
-name = "portable-atomic"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
-dependencies = [
- "portable-atomic",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,6 @@ exclude = [
 [dependencies]
 anyhow = "1.0.98"
 clap = { version = "4.5.43", features = ["derive"] }
-clap-verbosity-flag = "3.0.3"
-env_logger = "0.11.8"
-log = "0.4.27"
 pest = "2.8.1"
 pest_derive = "2.8.1"
 serde = { version = "1.0.219", features = ["derive", "rc"]}
@@ -34,7 +31,6 @@ serde_json = "1.0.142"
 serde_json_borrow = "0.9.0"
 clap_mangen = "0.2.29"
 clap_complete = "4.5.57"
-regex = "1.12.2"
 memmap2 = "0.9.9"
 colored = "3.1.1"
 serde_yaml = { version = "0.9", optional = true }

--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -500,7 +500,6 @@ impl QueryBuilder {
     /// Apply a regex to the last atom in the query:
     /// ```
     /// use jsongrep::query::{QueryBuilder, Query};
-    /// use regex::Regex;
     /// // Create a regex to match any string starting with "foo"
     /// let re = r"^foo";
     /// // Query: "foo.*"


### PR DESCRIPTION
None of these are used anywhere in src/: there is no verbosity flag on
the CLI, no log macros, and Query::Regex stores a plain String (the
/regex/ feature is not implemented yet). The only reference was a stray
`use regex::Regex;` in a QueryBuilder::regex doctest that never used
the import - removed.

Shrinks the normal dependency graph from 84 to 72 crates: less to
compile (native and the WASM playground build), less supply-chain
audit surface. Release binary size is unchanged (LTO was already
discarding the unused code).

When /regex/ matching is actually implemented, the dependency can
return alongside the implementation.


---

*This PR is one of a series from a full-repo review (each branch is independent off `main`). Where PRs touch the same files (`CHANGELOG.md`, `src/query/dfa.rs`, `src/main.rs`), conflicts are trivial - mostly CHANGELOG section concatenation - and I'm happy to rebase whichever land later.*
