### PR TITLE
fix(parser): reject /regex/ queries cleanly; make [usize::MAX] well-defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `/regex/` queries no longer panic: the parser now rejects them with a clean
+  "not implemented yet" error (`QueryParseError::UnsupportedFeature`) instead
+  of letting DFA construction hit `unimplemented!()` from the CLI, library,
+  and WASM playground.
+- Array index `[18446744073709551615]` (`usize::MAX`) no longer overflows
+  (panic in debug builds, silent wrap in release); it now matches nothing,
+  which is correct since an element at that index cannot exist.
+
+### Breaking
+
+- `QueryParseError` gains the `UnsupportedFeature` variant and is now
+  `#[non_exhaustive]`; downstream exhaustive matches need a wildcard arm.
+- `/regex/` query strings now return a parse error instead of parsing
+  successfully (and panicking on execution).
+
 ## [0.9.0] - 2026-04-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -450,8 +450,9 @@ determinizes to a
 execution. See the [grammar](./src/query/grammar) directory and the
 [`query`](./src/query) module for implementation details.
 
-> **Experimental:** The grammar supports `/regex/` syntax for matching field
-> names by pattern, but this is not yet fully implemented. Determinizing
+> **Not yet implemented:** The grammar reserves `/regex/` syntax for matching
+> field names by pattern, but the engine cannot execute it yet, so such
+> queries are rejected with an "Unsupported feature" error. Determinizing
 > overlapping regexes (e.g., `/a/` vs `/aab/`) requires subset construction
 > across multiple patterns - planned but not complete.
 

--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -54,7 +54,7 @@ pub enum Query {
     ArrayWildcard,
     /// Regex access, e.g., "/regex/".
     ///
-    /// Not implemented by the query engine yet: the string parser rejects
+    /// NOTE: Not implemented by the query engine yet: the string parser rejects
     /// `/regex/` syntax, and NFA/DFA construction panics on this variant.
     Regex(String),
     /// Optional access, e.g., "?".

--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -53,6 +53,9 @@ pub enum Query {
     /// Wildcard array access, e.g., "foo\[*\]".
     ArrayWildcard,
     /// Regex access, e.g., "/regex/".
+    ///
+    /// Not implemented by the query engine yet: the string parser rejects
+    /// `/regex/` syntax, and NFA/DFA construction panics on this variant.
     Regex(String),
     /// Optional access, e.g., "?".
     ///
@@ -494,6 +497,19 @@ impl QueryBuilder {
     }
 
     /// Adds a regex query to the query builder.
+    ///
+    /// <div class="warning">
+    ///
+    /// Regex field matching is **not implemented yet**: the query AST can
+    /// represent it, but building a [`QueryDFA`](crate::query::QueryDFA)
+    /// from a query containing [`Query::Regex`] currently panics with
+    /// `unimplemented!()`, and the query-string parser rejects `/regex/`
+    /// syntax with [`QueryParseError::UnsupportedFeature`]. Only use this
+    /// builder method for constructing/inspecting ASTs.
+    ///
+    /// [`QueryParseError::UnsupportedFeature`]: crate::query::QueryParseError::UnsupportedFeature
+    ///
+    /// </div>
     ///
     /// # Examples
     ///

--- a/src/query/dfa.rs
+++ b/src/query/dfa.rs
@@ -114,6 +114,14 @@ impl Display for QueryDFA {
 
 impl QueryDFA {
     /// Constructs a new [`QueryDFA`] from a constructed [`Query`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the query contains [`Query::Regex`], which the engine does
+    /// not implement yet. Queries obtained from the string parser can never
+    /// contain it (the parser rejects `/regex/` syntax with
+    /// [`QueryParseError::UnsupportedFeature`]); only hand-constructed ASTs
+    /// can reach this panic.
     #[must_use]
     pub fn from_query(query: &Query) -> Self {
         Self::build_from_query(query, false)
@@ -122,6 +130,11 @@ impl QueryDFA {
     /// Constructs a new case-insensitive [`QueryDFA`] from a constructed
     /// [`Query`]. Field names in the query and in JSON keys are compared
     /// after lowercasing.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the query contains [`Query::Regex`]; see
+    /// [`QueryDFA::from_query`].
     #[must_use]
     pub fn from_query_ignore_case(query: &Query) -> Self {
         Self::build_from_query(query, true)
@@ -309,8 +322,11 @@ impl DFABuilder {
             }
             Query::Index(idx) => {
                 // Represent individual index as a single-element range
-                // [idx: idx + 1)
-                self.collected_ranges.push((*idx, *idx + 1));
+                // [idx: idx + 1). Saturate on usize::MAX: the resulting
+                // empty range matches nothing, which is correct because an
+                // element at that index cannot exist (and it must not wrap
+                // to an inverted range or panic in debug builds).
+                self.collected_ranges.push((*idx, idx.saturating_add(1)));
             }
             Query::Range(s, e) => {
                 self.collected_ranges.push((
@@ -1637,6 +1653,40 @@ mod tests {
 
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].value, &Value::Number(1u64.into()));
+    }
+
+    #[test]
+    fn usize_max_index_matches_nothing_without_panic() {
+        // [usize::MAX] used to compute idx + 1, panicking in debug builds
+        // and silently wrapping to an inverted range in release. An element
+        // at that index cannot exist, so the query must simply match
+        // nothing.
+        let input = r#"{ "arr": [1, 2, 3] }"#;
+        let json: Value = serde_json::from_str(input).expect("hardcoded json");
+
+        let query = format!("arr.[{}]", usize::MAX);
+        let dfa = QueryDFA::from_query_str(&query).expect("valid query");
+        assert_eq!(dfa.find(&json).len(), 0);
+
+        // Sanity: a normal index on the same document still matches.
+        let dfa = QueryDFA::from_query_str("arr.[2]").expect("valid query");
+        assert_eq!(dfa.find(&json).len(), 1);
+    }
+
+    #[test]
+    fn usize_max_index_alongside_real_range() {
+        // The empty (MAX, MAX) label must not inherit or overlap any real
+        // range symbol: only the [0:2] branch of the disjunction matches.
+        let input = r#"{ "arr": [10, 20, 30] }"#;
+        let json: Value = serde_json::from_str(input).expect("hardcoded json");
+
+        let query = format!("arr.([{}] | [0:2])", usize::MAX);
+        let dfa = QueryDFA::from_query_str(&query).expect("valid query");
+        let matches = dfa.find(&json);
+
+        assert_eq!(matches.len(), 2);
+        assert_eq!(matches[0].value, &Value::Number(10u64.into()));
+        assert_eq!(matches[1].value, &Value::Number(20u64.into()));
     }
 
     #[test]

--- a/src/query/nfa.rs
+++ b/src/query/nfa.rs
@@ -129,6 +129,12 @@ impl Display for QueryNFA {
 
 impl QueryNFA {
     /// Construct an NFA recognizing the language defined by a query.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the query contains [`Query::Regex`], which the engine does
+    /// not implement yet (the query-string parser rejects `/regex/` syntax,
+    /// so only hand-constructed ASTs can reach this panic).
     #[must_use]
     pub fn from_query(query: &Query) -> Self {
         let mut temp_nfa = Self {
@@ -219,8 +225,10 @@ impl QueryNFA {
             }
             Query::Index(idx) => {
                 // Represent individual index as a single-element range
-                // [idx: idx + 1)
-                let range = TransitionLabel::Range(*idx, *idx + 1);
+                // [idx: idx + 1). Saturate on usize::MAX (see
+                // `DFABuilder::extract_symbols`): the empty range matches
+                // nothing rather than wrapping or panicking.
+                let range = TransitionLabel::Range(*idx, idx.saturating_add(1));
                 self.pos_to_label.push(range);
             }
             Query::Range(s, e) => {

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -70,11 +70,14 @@ pub use pest_parser::{QueryDSLParser, Rule};
 
 /// Represents errors that can occur while parsing a JSON query.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum QueryParseError {
     /// Unexpected token encountered during parsing.
     UnexpectedToken(String),
     /// The input ended unexpectedly, indicating an incomplete query.
     UnexpectedEndOfInput,
+    /// The query uses syntax that is recognized but not implemented yet.
+    UnsupportedFeature(String),
 }
 
 impl Error for QueryParseError {}
@@ -88,15 +91,14 @@ impl fmt::Display for QueryParseError {
             Self::UnexpectedEndOfInput => {
                 write!(f, "Unexpected end of input")
             }
+            Self::UnsupportedFeature(feature) => {
+                write!(f, "Unsupported feature: {feature}")
+            }
         }
     }
 }
 
 /// Parse an input query string into a [`Query`].
-///
-/// # Panics
-///
-/// Panics if the input query string is invalid.
 ///
 /// # Errors
 ///
@@ -105,8 +107,9 @@ pub fn parse_query(input: &str) -> Result<Query, QueryParseError> {
     let mut pairs = QueryDSLParser::parse(Rule::query, input)
         .map_err(|e| QueryParseError::UnexpectedToken(e.to_string()))?;
 
-    // Get and unwrap the `query` rule
-    let query = pairs.next().expect("Empty query string");
+    // Get the `query` rule. A successful pest parse always yields it, but
+    // return an error rather than panicking if that invariant ever breaks.
+    let query = pairs.next().ok_or(QueryParseError::UnexpectedEndOfInput)?;
 
     // Query rule contains disjunction
     let mut inner = query.into_inner();
@@ -452,7 +455,7 @@ fn parse_range(
     }
 }
 
-/// Parse a regex rule into a `Query::Regex`.
+/// Reject a grammar-valid `/regex/` atom with a clean "unsupported" error.
 fn parse_regex(
     pair: &pest::iterators::Pair<Rule>,
 ) -> Result<Query, QueryParseError> {
@@ -463,17 +466,16 @@ fn parse_regex(
         )));
     }
 
-    let regex_str = pair.as_str();
-    if regex_str.len() < 2
-        || !regex_str.starts_with('/')
-        || !regex_str.ends_with('/')
-    {
-        return Err(QueryParseError::UnexpectedToken(regex_str.to_string()));
-    }
-
-    let pattern = &regex_str[1..regex_str.len() - 1];
-    let unescaped_pattern = pattern.replace("\\/", "/");
-    Ok(Query::Regex(unescaped_pattern))
+    // NOTE: `/regex/` field matching parses but is not implemented by the
+    // NFA/DFA construction (which would hit `unimplemented!()` and panic).
+    // Reject it here with a clean error until the feature lands, so that no
+    // grammar-valid query string can panic the CLI, the library, or the WASM
+    // playground.
+    Err(QueryParseError::UnsupportedFeature(format!(
+        "regex field matching ({}) is not implemented yet; match literal \
+         fields, wildcards, or disjunctions instead",
+        pair.as_str()
+    )))
 }
 
 #[cfg(test)]
@@ -495,10 +497,24 @@ mod tests {
     }
 
     #[test]
-    fn parse_single_regex() {
-        let query = "/foo.bar/";
-        let result = parse_query(query).unwrap();
-        assert_eq!(query, result.to_string());
+    fn parse_regex_rejected_as_unsupported() {
+        // The grammar recognizes /regex/ but the engine cannot execute it
+        // yet; parsing must fail cleanly instead of letting DFA construction
+        // panic later.
+        let result = parse_query("/foo.bar/");
+        assert!(
+            matches!(result, Err(QueryParseError::UnsupportedFeature(_))),
+            "Actual result: {result:?}"
+        );
+    }
+
+    #[test]
+    fn parse_regex_in_sequence_rejected() {
+        let result = parse_query("users./na.*/.email");
+        assert!(
+            matches!(result, Err(QueryParseError::UnsupportedFeature(_))),
+            "Actual result: {result:?}"
+        );
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -73,6 +73,44 @@ mod tests {
     }
 
     #[test]
+    fn regex_query_errors_cleanly_instead_of_panicking() {
+        // /regex/ syntax is grammar-valid but unimplemented; it must exit
+        // with a normal error (code 1), not a panic (code 101).
+        let assert = run_main(&["/foo.*/", SIMPLE_JSON_FILEPATH]);
+        let assert = assert.failure().code(1);
+        let stderr = String::from_utf8(assert.get_output().stderr.clone())
+            .expect("Invalid UTF-8 output");
+        assert!(
+            stderr.contains("not implemented"),
+            "expected a clean unsupported-feature error, got: {stderr:?}"
+        );
+        assert!(
+            !stderr.contains("panicked"),
+            "regex query must not panic: {stderr:?}"
+        );
+    }
+
+    #[test]
+    fn usize_max_index_no_panic() {
+        let query = format!("[{}]", usize::MAX);
+        let output = run_main(&[
+            &query,
+            SIMPLE_JSON_FILEPATH,
+            "--count",
+            "--no-display",
+            "--porcelain",
+        ])
+        .success()
+        .code(0)
+        .get_output()
+        .stdout
+        .clone();
+        let output_str =
+            String::from_utf8(output).expect("Invalid UTF-8 output");
+        assert_eq!(output_str.trim(), "0");
+    }
+
+    #[test]
     fn simple_query() {
         // Test a simple query "age" on simple.json. The output format is a
         // path header line followed by the JSON value, e.g.:


### PR DESCRIPTION
Two grammar-valid inputs could take down the process:

- `jg '/foo/'` panicked with unimplemented!() during DFA construction
  (reachable from the CLI, jsongrep::grep, and the WASM playground,
  where a panic is an unrecoverable trap). The parser now rejects
  /regex/ syntax with the new QueryParseError::UnsupportedFeature and
  an actionable message; the AST variant and QueryBuilder::regex remain
  for the future implementation, with documented panics on the
  from_query constructors (only hand-built ASTs can reach them).

- `[18446744073709551615]` computed idx + 1: panic in debug builds,
  silent wrap to an inverted (never-matching) range in release. Both
  NFA and DFA construction now saturate, giving well-defined "matches
  nothing" semantics - correct, since an element at usize::MAX cannot
  exist.

Also: parse_query's internal expect() replaced with a proper error
(its false "# Panics" doc section is gone), Query::Regex variant and
README/CHANGELOG updated.

Breaking (0.10.0): QueryParseError gains UnsupportedFeature and is now
#[non_exhaustive]; /regex/ strings now fail to parse instead of parsing
and panicking on execution.

Tests: parser rejection (bare and mid-sequence), CLI exits 1 with a
clean error (not panic code 101), usize::MAX index matches nothing
(portable via usize::MAX, catches the debug-build panic), and a
mixed disjunction ([MAX] | [0:2]) proving the empty range cannot
inherit a real range symbol.


---

*This PR is one of a series from a full-repo review (each branch is independent off `main`). Where PRs touch the same files (`CHANGELOG.md`, `src/query/dfa.rs`, `src/main.rs`), conflicts are trivial - mostly CHANGELOG section concatenation - and I'm happy to rebase whichever land later.*
