### PR TITLE
fix(cli): read input as bytes; fall back from mmap for non-regular files

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -99,25 +99,32 @@ enum GenerateCommand {
     },
 }
 
+/// Minimum file size for which memory-mapping is attempted. Below this,
+/// a plain read is at least as fast (mmap setup and page-fault overhead
+/// dominate for small files) and avoids mmap's file-truncation hazards.
+const MMAP_MIN_FILE_SIZE: u64 = 1 << 20; // 1 MiB
+
 /// Possible input sources for jsongrep.
+///
+/// Input is kept as raw bytes so that binary formats (CBOR, `MessagePack`)
+/// work from any source; UTF-8 is validated only when a text format needs
+/// it.
 enum Input {
-    /// Buffered standard input.
-    Stdin(String),
+    /// Fully buffered input: stdin, small files, non-regular files (FIFOs,
+    /// process substitution), and the fallback when mmap fails.
+    Buffer(Vec<u8>),
     /// A memory-mapped file from the file system. Assumes an immutable handle.
     File(Mmap),
 }
 
 impl Input {
     fn to_str(&self) -> Result<&str, Utf8Error> {
-        match self {
-            Self::Stdin(buffer) => Ok(buffer.as_str()),
-            Self::File(mmap) => str::from_utf8(mmap),
-        }
+        str::from_utf8(self.to_bytes())
     }
 
     fn to_bytes(&self) -> &[u8] {
         match self {
-            Self::Stdin(buf) => buf.as_bytes(),
+            Self::Buffer(buf) => buf.as_slice(),
             Self::File(mmap) => mmap.as_ref(),
         }
     }
@@ -228,22 +235,43 @@ impl Input {
 /// piped input, prints the help message and exits with an error.
 fn parse_input_content(input: Option<PathBuf>) -> Result<Input> {
     if let Some(path) = input {
-        let fd =
+        let mut fd =
             OpenOptions::new().read(true).open(&path).with_context(|| {
                 format!("Failed to open file {}", path.display())
             })?;
 
-        // SAFETY:
-        // mmap is unsafe if the backing file is modified, either by ourselves or by
-        // other processes.
-        // We will never modify the file, and if other processes do,
-        // there is not much we can do about it.
-        let map = unsafe {
-            MmapOptions::new().map(&fd).with_context(|| {
-                format!("Failed to mmap file {}", path.display())
-            })?
-        };
-        Ok(Input::File(map))
+        // Only mmap large regular files. Non-regular files (FIFOs, process
+        // substitution like `jg q <(curl ...)`, character devices) cannot be
+        // mapped, and small files gain nothing from mapping. If mapping
+        // fails anyway, fall back to a plain read instead of erroring.
+        let metadata = fd.metadata().ok();
+        let is_large_regular_file = metadata
+            .as_ref()
+            .is_some_and(|m| m.is_file() && m.len() >= MMAP_MIN_FILE_SIZE);
+
+        if is_large_regular_file {
+            // SAFETY:
+            // mmap is unsafe if the backing file is modified, either by
+            // ourselves or by other processes. We will never modify the
+            // file, and if other processes do, there is not much we can do
+            // about it.
+            if let Ok(map) = unsafe { MmapOptions::new().map(&fd) } {
+                return Ok(Input::File(map));
+            }
+        }
+
+        // Capacity hint capped at the mmap threshold: only files below it
+        // (or rare mmap fallbacks) reach this path, and a stale/huge stat
+        // length must not trigger a giant allocation.
+        let capacity_hint = metadata
+            .map_or(0, |m| m.len().min(MMAP_MIN_FILE_SIZE))
+            .try_into()
+            .unwrap_or(0);
+        let mut buffer = Vec::with_capacity(capacity_hint);
+        fd.read_to_end(&mut buffer).with_context(|| {
+            format!("Failed to read file {}", path.display())
+        })?;
+        Ok(Input::Buffer(buffer))
     } else {
         if io::stdin().is_terminal() {
             // No piped input and no file specified
@@ -251,9 +279,12 @@ fn parse_input_content(input: Option<PathBuf>) -> Result<Input> {
             cmd.print_help()?;
             anyhow::bail!("No input specified");
         }
-        let mut buffer = String::new();
-        io::stdin().read_to_string(&mut buffer)?;
-        Ok(Input::Stdin(buffer))
+        // Read raw bytes: binary formats (CBOR, MessagePack) are valid
+        // stdin inputs; UTF-8 is only required (and validated) for text
+        // formats.
+        let mut buffer = Vec::new();
+        io::stdin().read_to_end(&mut buffer)?;
+        Ok(Input::Buffer(buffer))
     }
 }
 
@@ -322,9 +353,7 @@ where
     };
     let json_str: &str = match &json_string_owned {
         Some(s) => s.as_str(),
-        None => input_content
-            .to_str()
-            .context("File contents are not valid UTF-8")?,
+        None => input_content.to_str().context("Input is not valid UTF-8")?,
     };
     let json: Value = serde_json::from_str(json_str)
         .with_context(|| format!("Failed to parse as {format}"))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,9 +99,16 @@ enum GenerateCommand {
     },
 }
 
-/// Minimum file size for which memory-mapping is attempted. Below this,
-/// a plain read is at least as fast (mmap setup and page-fault overhead
-/// dominate for small files) and avoids mmap's file-truncation hazards.
+/// Minimum file size for which memory-mapping is attempted.
+///
+/// For small files, it is likely that a single read call is at least as fast or faster than mmap
+/// (mmap setup and page-fault overhead dominate for small files) and avoids mmap's file-truncation
+/// hazards.
+///
+/// NOTE: in the future when globbing (<https://github.com/micahkepe/jsongrep/issues/33>) and
+/// recursive searching are enabled, can look into other heuristics for performance.
+///
+/// See: <https://burntsushi.net/ripgrep/#mechanics>.
 const MMAP_MIN_FILE_SIZE: u64 = 1 << 20; // 1 MiB
 
 /// Possible input sources for jsongrep.

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -288,6 +288,57 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
+    fn non_regular_file_input_works() {
+        // FIFOs (and process substitution, `jg q <(...)`) cannot be mmap'd;
+        // jg must fall back to reading them.
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let fifo_path = dir.path().join("input.fifo");
+        let status = std::process::Command::new("mkfifo")
+            .arg(&fifo_path)
+            .status()
+            .expect("run mkfifo");
+        assert!(status.success(), "mkfifo failed");
+
+        // Writing blocks until the reader (jg) opens the pipe, so write from
+        // a separate thread.
+        let writer = std::thread::spawn({
+            let fifo_path = fifo_path.clone();
+            move || {
+                std::fs::write(&fifo_path, br#"{"a": 41}"#)
+                    .expect("write to fifo");
+            }
+        });
+
+        let output = query_output(&[
+            "a",
+            fifo_path.to_str().expect("fifo path"),
+            "--no-path",
+            "--compact",
+        ]);
+        writer.join().expect("join writer thread");
+        assert_eq!(output.trim(), "41");
+    }
+
+    #[test]
+    fn large_file_takes_mmap_path() {
+        // Files at or above the mmap threshold (1 MiB) go through the
+        // memory-mapped path; verify it still parses and matches.
+        let mut big = String::from(r#"{"pad": ""#);
+        big.push_str(&"x".repeat(2 * 1024 * 1024));
+        big.push_str(r#"", "answer": 42}"#);
+        let tmp = temp_file_with(".json", big.as_bytes());
+
+        let output = query_output(&[
+            "answer",
+            tmp.path().to_str().expect("temp path"),
+            "--no-path",
+            "--compact",
+        ]);
+        assert_eq!(output.trim(), "42");
+    }
+
+    #[test]
     fn jsonl_stdin_with_format_flag() {
         let jsonl_content =
             std::fs::read_to_string(SIMPLE_JSONL_FILEPATH).expect("read jsonl");
@@ -430,6 +481,47 @@ mod tests {
         ciborium::into_writer(&value, &mut cbor_buf)
             .expect("CBOR serialization");
         temp_file_with(suffix, &cbor_buf)
+    }
+
+    #[test]
+    fn cbor_via_stdin() {
+        // Binary formats must work over stdin: input is read as raw bytes,
+        // not UTF-8 text.
+        let value: serde_json::Value =
+            serde_json::from_str(SIMPLE_JSON_STR).expect("parse simple.json");
+        let mut cbor_buf = Vec::new();
+        ciborium::into_writer(&value, &mut cbor_buf)
+            .expect("CBOR serialization");
+
+        let mut cmd =
+            Command::cargo_bin("jg").expect("Failed to find main binary");
+        let assert = cmd
+            .args(["-f", "cbor", "age", "--no-path", "--compact"])
+            .write_stdin(cbor_buf)
+            .assert()
+            .success();
+        let output = String::from_utf8(assert.get_output().stdout.clone())
+            .expect("Invalid UTF-8 output");
+        assert_eq!(output.trim(), json_reference("age").trim());
+    }
+
+    #[test]
+    fn msgpack_via_stdin() {
+        let value: serde_json::Value =
+            serde_json::from_str(SIMPLE_JSON_STR).expect("parse simple.json");
+        let msgpack_buf =
+            rmp_serde::to_vec(&value).expect("MessagePack serialization");
+
+        let mut cmd =
+            Command::cargo_bin("jg").expect("Failed to find main binary");
+        let assert = cmd
+            .args(["-f", "msgpack", "name.first", "--no-path", "--compact"])
+            .write_stdin(msgpack_buf)
+            .assert()
+            .success();
+        let output = String::from_utf8(assert.get_output().stdout.clone())
+            .expect("Invalid UTF-8 output");
+        assert_eq!(output.trim(), json_reference("name.first").trim());
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -321,7 +321,7 @@ mod tests {
     }
 
     #[test]
-    fn large_file_takes_mmap_path() {
+    fn large_file_parses_correctly() {
         // Files at or above the mmap threshold (1 MiB) go through the
         // memory-mapped path; verify it still parses and matches.
         let mut big = String::from(r#"{"pad": ""#);


### PR DESCRIPTION
Two input-handling holes:

- stdin was read with read_to_string, so the advertised CBOR and
  MessagePack support failed on stdin with "stream did not contain
  valid UTF-8" (binary data is rarely valid UTF-8). Input is now raw
  bytes everywhere (Input::Buffer(Vec<u8>)); UTF-8 is validated only
  when a text format actually needs a &str.

- Named inputs were unconditionally mmap'd, so FIFOs and process
  substitution (`jg q <(curl ...)`) failed with "Failed to mmap file
  /dev/fd/11". Now only regular files >= 1 MiB are mapped; non-regular
  files, small files (where mapping gains nothing), and mmap failures
  fall back to a plain read. The read path's allocation hint is capped
  at the mmap threshold so a stale stat length cannot trigger a giant
  allocation.

Verified empirically: `jg a <(echo ...)` and CBOR bytes over stdin both
work now (both failed before). New tests: CBOR and MessagePack via
stdin, FIFO input via mkfifo (unix), and a 2 MiB file exercising the
mmap path.


---

*This PR is one of a series from a full-repo review (each branch is independent off `main`). Where PRs touch the same files (`CHANGELOG.md`, `src/query/dfa.rs`, `src/main.rs`), conflicts are trivial - mostly CHANGELOG section concatenation - and I'm happy to rebase whichever land later.*
