### PR TITLE
feat(cli): -r/--raw-output prints matched strings unquoted (jq -r)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `#[non_exhaustive]`; downstream exhaustive matches need a wildcard arm.
 - `/regex/` query strings now return a parse error instead of parsing
   successfully (and panicking on execution).
+- `jsongrep::utils::write_colored_result` now takes a `WriteOptions` struct
+  instead of separate `pretty`, `show_path`, and `raw` parameters.
 
 ## [0.9.0] - 2026-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `jg` CLI caps query compilation at 2^18 DFA states (a clean error
   after ~0.4 s worst case instead of unbounded time/memory), and the WASM
   playground at 2^16.
+- `-r`/`--raw-output`: print matched strings without JSON quotes or escaping
+  (like `jq -r`), enabling `VAR=$(... | jg -r field)` shell pipelines.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ Arguments:
 Options:
   -i, --ignore-case      Case insensitive search
       --compact          Do not pretty-print the JSON output
+  -r, --raw-output       Print matched strings without JSON quotes or escaping (like `jq -r`)
       --count            Display count of number of matches
       --depth            Display depth of the input document
       --porcelain        Machine-readable output: strip labels and colors (useful for piping)
@@ -389,6 +390,17 @@ curl -s https://api.nobelprize.org/v1/prize.json | jg -F firstname --count --por
 
 ```
 1026
+```
+
+**Raw string output** (like `jq -r`) for shell pipelines:
+
+```bash
+TOKEN=$(echo '{"auth": {"token": "abc123"}}' | jg -r 'auth.token')
+echo "$TOKEN"
+```
+
+```
+abc123
 ```
 
 **Piping to other tools:**

--- a/examples/parse_and_query.rs
+++ b/examples/parse_and_query.rs
@@ -10,7 +10,7 @@
 use jsongrep::{
     Value,
     query::{Query, QueryDFA},
-    utils::write_colored_result,
+    utils::{WriteOptions, write_colored_result},
 };
 use std::io::{self, BufWriter, Write};
 
@@ -37,9 +37,11 @@ fn main() -> anyhow::Result<()> {
             &mut writer,
             result.value,
             &result.path,
-            true,
-            true,
-            false,
+            &WriteOptions {
+                pretty: true,
+                show_path: true,
+                ..Default::default()
+            },
         )?;
     }
     writer.write_all(b"\n")?;
@@ -65,9 +67,11 @@ fn main() -> anyhow::Result<()> {
                 &mut writer,
                 result.value,
                 &result.path,
-                true,
-                true,
-                false,
+                &WriteOptions {
+                    pretty: true,
+                    show_path: true,
+                    ..Default::default()
+                },
             )?;
         }
     }
@@ -89,9 +93,11 @@ fn main() -> anyhow::Result<()> {
             &mut writer,
             result.value,
             &result.path,
-            true,
-            true,
-            false,
+            &WriteOptions {
+                pretty: true,
+                show_path: true,
+                ..Default::default()
+            },
         )?;
     }
 

--- a/examples/parse_and_query.rs
+++ b/examples/parse_and_query.rs
@@ -39,6 +39,7 @@ fn main() -> anyhow::Result<()> {
             &result.path,
             true,
             true,
+            false,
         )?;
     }
     writer.write_all(b"\n")?;
@@ -66,6 +67,7 @@ fn main() -> anyhow::Result<()> {
                 &result.path,
                 true,
                 true,
+                false,
             )?;
         }
     }
@@ -89,6 +91,7 @@ fn main() -> anyhow::Result<()> {
             &result.path,
             true,
             true,
+            false,
         )?;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,12 @@ struct Args {
     /// Do not pretty-print the JSON output.
     #[arg(long, action = ArgAction::SetTrue)]
     compact: bool,
+    /// Print matched strings without JSON quotes or escaping (like `jq -r`).
+    ///
+    /// Useful in shell pipelines: `TOKEN=$(... | jg -r token)`. Non-string
+    /// values print as JSON, unchanged.
+    #[arg(short = 'r', long, action = ArgAction::SetTrue)]
+    raw_output: bool,
     /// Display count of number of matches.
     #[arg(long, action = ArgAction::SetTrue, conflicts_with = "depth")]
     count: bool,
@@ -510,6 +516,7 @@ fn main() -> Result<()> {
                             &result.path,
                             pretty,
                             show_path,
+                            args.raw_output,
                         )?;
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use std::{
 use jsongrep::{
     commands,
     query::{Query, QueryDFA},
-    utils::{depth, write_colored_result},
+    utils::{WriteOptions, depth, write_colored_result},
 };
 
 /// Query an input JSON document against a jsongrep query.
@@ -514,9 +514,11 @@ fn main() -> Result<()> {
                             &mut writer,
                             result.value,
                             &result.path,
-                            pretty,
-                            show_path,
-                            args.raw_output,
+                            &WriteOptions {
+                                pretty,
+                                show_path,
+                                raw: args.raw_output,
+                            },
                         )?;
                     }
                 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -31,6 +31,11 @@ pub fn depth(json: &Value) -> usize {
 /// Silently returns `Ok(())` on broken pipe so that piping to tools like
 /// `less` or `head` exits cleanly.
 ///
+/// When `raw` is set, a matched value that is a string is written without
+/// JSON quotes or escaping (like `jq -r`), so shell pipelines get the bare
+/// text: `TOKEN=$(... | jg -r token)`. Non-string values are unaffected
+/// (their JSON form is already their raw form).
+///
 /// # Errors
 ///
 /// Returns an error if writing to `writer` fails.
@@ -40,6 +45,7 @@ pub fn write_colored_result<W: Write>(
     path: &[PathType],
     pretty: bool,
     show_path: bool,
+    raw: bool,
 ) -> anyhow::Result<()> {
     let path = path
         .iter()
@@ -51,7 +57,14 @@ pub fn write_colored_result<W: Write>(
         if show_path && !path.is_empty() {
             writeln!(writer, "{}:", path.bold().magenta())?;
         }
-        write_colored_json(writer, value, 0, pretty)?;
+        if raw && let Value::Str(s) = value {
+            // Raw output: the string's contents, not its JSON encoding.
+            // Escape sequences in the source (e.g. \n) have already been
+            // decoded by the JSON parser, so this writes real newlines etc.
+            write!(writer, "{s}")?;
+        } else {
+            write_colored_json(writer, value, 0, pretty)?;
+        }
         writeln!(writer)?;
         Ok(())
     })();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -27,6 +27,17 @@ pub fn depth(json: &Value) -> usize {
 // Colorized JSON Output
 // ==============================================================================
 
+/// Available options for printing matches.
+#[derive(Debug, Default)]
+pub struct WriteOptions {
+    /// Whether to pretty print the output.
+    pub pretty: bool,
+    /// Whether to include the file paths for matches.
+    pub show_path: bool,
+    /// Whether to print the raw output or auto-escape characters.
+    pub raw: bool,
+}
+
 /// Write a single query result (path header + colorized JSON value) to `writer`.
 /// Silently returns `Ok(())` on broken pipe so that piping to tools like
 /// `less` or `head` exits cleanly.
@@ -43,9 +54,7 @@ pub fn write_colored_result<W: Write>(
     writer: &mut W,
     value: &Value,
     path: &[PathType],
-    pretty: bool,
-    show_path: bool,
-    raw: bool,
+    options: &WriteOptions,
 ) -> anyhow::Result<()> {
     let path = path
         .iter()
@@ -54,16 +63,18 @@ pub fn write_colored_result<W: Write>(
         .join(".");
 
     let result = (|| -> io::Result<()> {
-        if show_path && !path.is_empty() {
+        if options.show_path && !path.is_empty() {
             writeln!(writer, "{}:", path.bold().magenta())?;
         }
-        if raw && let Value::Str(s) = value {
+        if options.raw
+            && let Value::Str(s) = value
+        {
             // Raw output: the string's contents, not its JSON encoding.
             // Escape sequences in the source (e.g. \n) have already been
             // decoded by the JSON parser, so this writes real newlines etc.
             write!(writer, "{s}")?;
         } else {
-            write_colored_json(writer, value, 0, pretty)?;
+            write_colored_json(writer, value, 0, options.pretty)?;
         }
         writeln!(writer)?;
         Ok(())

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -223,15 +223,10 @@ mod tests {
     fn porcelain_match_output_is_compact_json_lines() {
         // --porcelain must imply --compact: one JSON value per line, no
         // pretty-printing, parseable by line-oriented consumers.
-        let mut cmd =
-            Command::cargo_bin("jg").expect("Failed to find main binary");
-        let assert = cmd
-            .args(["--porcelain", "--no-path", "users[*]"])
-            .write_stdin(r#"{"users": [{"a": 1}, {"b": 2}]}"#)
-            .assert()
-            .success();
-        let output = String::from_utf8(assert.get_output().stdout.clone())
-            .expect("Invalid UTF-8 output");
+        let output = query_stdin_output(
+            &["--porcelain", "--no-path", "users[*]"],
+            r#"{"users": [{"a": 1}, {"b": 2}]}"#,
+        );
         assert_eq!(output, "{\"a\":1}\n{\"b\":2}\n");
         for line in output.lines() {
             serde_json::from_str::<Value>(line)
@@ -265,102 +260,63 @@ mod tests {
 
     #[test]
     fn raw_output_unquotes_strings() {
-        let mut cmd =
-            Command::cargo_bin("jg").expect("Failed to find main binary");
-        let assert = cmd
-            .args(["-r", "name", "--no-path"])
-            .write_stdin(r#"{"name": "Ada Lovelace"}"#)
-            .assert()
-            .success();
-        let output = String::from_utf8(assert.get_output().stdout.clone())
-            .expect("Invalid UTF-8 output");
+        let output = query_stdin_output(
+            &["-r", "name", "--no-path"],
+            r#"{"name": "Ada Lovelace"}"#,
+        );
         assert_eq!(output, "Ada Lovelace\n");
     }
 
     #[test]
     fn raw_output_decodes_escapes() {
         // \n and \" in the JSON source must come out as real characters.
-        let mut cmd =
-            Command::cargo_bin("jg").expect("Failed to find main binary");
-        let assert = cmd
-            .args(["-r", "msg", "--no-path"])
-            .write_stdin(r#"{"msg": "line1\nline\"2\""}"#)
-            .assert()
-            .success();
-        let output = String::from_utf8(assert.get_output().stdout.clone())
-            .expect("Invalid UTF-8 output");
+        let output = query_stdin_output(
+            &["-r", "msg", "--no-path"],
+            r#"{"msg": "line1\nline\"2\""}"#,
+        );
         assert_eq!(output, "line1\nline\"2\"\n");
     }
 
     #[test]
     fn raw_output_empty_string_is_bare_newline() {
-        let mut cmd =
-            Command::cargo_bin("jg").expect("Failed to find main binary");
-        let assert = cmd
-            .args(["-r", "s", "--no-path"])
-            .write_stdin(r#"{"s": ""}"#)
-            .assert()
-            .success();
-        let output = String::from_utf8(assert.get_output().stdout.clone())
-            .expect("Invalid UTF-8 output");
+        let output =
+            query_stdin_output(&["-r", "s", "--no-path"], r#"{"s": ""}"#);
         assert_eq!(output, "\n");
     }
 
     #[test]
     fn raw_output_preserves_trailing_newline_plus_record_newline() {
         // jq -r prints the string contents then its own record newline.
-        let mut cmd =
-            Command::cargo_bin("jg").expect("Failed to find main binary");
-        let assert = cmd
-            .args(["-r", "s", "--no-path"])
-            .write_stdin(r#"{"s": "x\n"}"#)
-            .assert()
-            .success();
-        let output = String::from_utf8(assert.get_output().stdout.clone())
-            .expect("Invalid UTF-8 output");
+        let output =
+            query_stdin_output(&["-r", "s", "--no-path"], r#"{"s": "x\n"}"#);
         assert_eq!(output, "x\n\n");
     }
 
     #[test]
     fn raw_output_with_path_header() {
-        let mut cmd =
-            Command::cargo_bin("jg").expect("Failed to find main binary");
-        let assert = cmd
-            .args(["-r", "name", "--with-path"])
-            .write_stdin(r#"{"name": "Ada"}"#)
-            .assert()
-            .success();
-        let output = String::from_utf8(assert.get_output().stdout.clone())
-            .expect("Invalid UTF-8 output");
+        let output = query_stdin_output(
+            &["-r", "name", "--with-path"],
+            r#"{"name": "Ada"}"#,
+        );
         assert_eq!(output, "name:\nAda\n");
     }
 
     #[test]
     fn raw_output_leaves_non_strings_as_json() {
-        let mut cmd =
-            Command::cargo_bin("jg").expect("Failed to find main binary");
-        let assert = cmd
-            .args(["-r", "*", "--no-path", "--compact"])
-            .write_stdin(r#"{"n": 42, "b": true, "o": {"k": "v"}}"#)
-            .assert()
-            .success();
-        let output = String::from_utf8(assert.get_output().stdout.clone())
-            .expect("Invalid UTF-8 output");
+        let output = query_stdin_output(
+            &["-r", "*", "--no-path", "--compact"],
+            r#"{"n": 42, "b": true, "o": {"k": "v"}}"#,
+        );
         assert_eq!(output, "42\ntrue\n{\"k\":\"v\"}\n");
     }
 
     #[test]
     fn raw_output_only_affects_top_level_strings() {
         // A string nested inside a matched object keeps its JSON quoting.
-        let mut cmd =
-            Command::cargo_bin("jg").expect("Failed to find main binary");
-        let assert = cmd
-            .args(["-r", "user", "--no-path", "--compact"])
-            .write_stdin(r#"{"user": {"name": "Ada"}}"#)
-            .assert()
-            .success();
-        let output = String::from_utf8(assert.get_output().stdout.clone())
-            .expect("Invalid UTF-8 output");
+        let output = query_stdin_output(
+            &["-r", "user", "--no-path", "--compact"],
+            r#"{"user": {"name": "Ada"}}"#,
+        );
         assert_eq!(output, "{\"name\":\"Ada\"}\n");
     }
 
@@ -414,6 +370,15 @@ mod tests {
     /// across formats without worrying about whitespace differences.
     fn query_output(args: &[&str]) -> String {
         let assert = run_main(args).success().code(0);
+        String::from_utf8(assert.get_output().stdout.clone())
+            .expect("Invalid UTF-8 output")
+    }
+
+    /// Like [`query_output`], but pipes `stdin` into the process.
+    fn query_stdin_output(args: &[&str], stdin: impl Into<Vec<u8>>) -> String {
+        let mut cmd =
+            Command::cargo_bin("jg").expect("Failed to find main binary");
+        let assert = cmd.args(args).write_stdin(stdin).assert().success();
         String::from_utf8(assert.get_output().stdout.clone())
             .expect("Invalid UTF-8 output")
     }
@@ -529,16 +494,10 @@ mod tests {
     fn jsonl_stdin_with_format_flag() {
         let jsonl_content =
             std::fs::read_to_string(SIMPLE_JSONL_FILEPATH).expect("read jsonl");
-        let mut cmd =
-            Command::cargo_bin("jg").expect("Failed to find main binary");
-        let assert = cmd
-            .args(["-f", "jsonl", "[0].email", "--no-path", "--compact"])
-            .write_stdin(jsonl_content)
-            .assert()
-            .success()
-            .code(0);
-        let output = String::from_utf8(assert.get_output().stdout.clone())
-            .expect("Invalid UTF-8 output");
+        let output = query_stdin_output(
+            &["-f", "jsonl", "[0].email", "--no-path", "--compact"],
+            jsonl_content,
+        );
         assert_eq!(
             output.trim(),
             r#""bguise0@indiegogo.com""#,
@@ -679,16 +638,10 @@ mod tests {
         let mut cbor_buf = Vec::new();
         ciborium::into_writer(&value, &mut cbor_buf)
             .expect("CBOR serialization");
-
-        let mut cmd =
-            Command::cargo_bin("jg").expect("Failed to find main binary");
-        let assert = cmd
-            .args(["-f", "cbor", "age", "--no-path", "--compact"])
-            .write_stdin(cbor_buf)
-            .assert()
-            .success();
-        let output = String::from_utf8(assert.get_output().stdout.clone())
-            .expect("Invalid UTF-8 output");
+        let output = query_stdin_output(
+            &["-f", "cbor", "age", "--no-path", "--compact"],
+            cbor_buf,
+        );
         assert_eq!(output.trim(), json_reference("age").trim());
     }
 
@@ -698,16 +651,10 @@ mod tests {
             serde_json::from_str(SIMPLE_JSON_STR).expect("parse simple.json");
         let msgpack_buf =
             rmp_serde::to_vec(&value).expect("MessagePack serialization");
-
-        let mut cmd =
-            Command::cargo_bin("jg").expect("Failed to find main binary");
-        let assert = cmd
-            .args(["-f", "msgpack", "name.first", "--no-path", "--compact"])
-            .write_stdin(msgpack_buf)
-            .assert()
-            .success();
-        let output = String::from_utf8(assert.get_output().stdout.clone())
-            .expect("Invalid UTF-8 output");
+        let output = query_stdin_output(
+            &["-f", "msgpack", "name.first", "--no-path", "--compact"],
+            msgpack_buf,
+        );
         assert_eq!(output.trim(), json_reference("name.first").trim());
     }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -260,6 +260,111 @@ mod tests {
     }
 
     // ==============================================================================
+    // Raw output (-r) tests
+    // ==============================================================================
+
+    #[test]
+    fn raw_output_unquotes_strings() {
+        let mut cmd =
+            Command::cargo_bin("jg").expect("Failed to find main binary");
+        let assert = cmd
+            .args(["-r", "name", "--no-path"])
+            .write_stdin(r#"{"name": "Ada Lovelace"}"#)
+            .assert()
+            .success();
+        let output = String::from_utf8(assert.get_output().stdout.clone())
+            .expect("Invalid UTF-8 output");
+        assert_eq!(output, "Ada Lovelace\n");
+    }
+
+    #[test]
+    fn raw_output_decodes_escapes() {
+        // \n and \" in the JSON source must come out as real characters.
+        let mut cmd =
+            Command::cargo_bin("jg").expect("Failed to find main binary");
+        let assert = cmd
+            .args(["-r", "msg", "--no-path"])
+            .write_stdin(r#"{"msg": "line1\nline\"2\""}"#)
+            .assert()
+            .success();
+        let output = String::from_utf8(assert.get_output().stdout.clone())
+            .expect("Invalid UTF-8 output");
+        assert_eq!(output, "line1\nline\"2\"\n");
+    }
+
+    #[test]
+    fn raw_output_empty_string_is_bare_newline() {
+        let mut cmd =
+            Command::cargo_bin("jg").expect("Failed to find main binary");
+        let assert = cmd
+            .args(["-r", "s", "--no-path"])
+            .write_stdin(r#"{"s": ""}"#)
+            .assert()
+            .success();
+        let output = String::from_utf8(assert.get_output().stdout.clone())
+            .expect("Invalid UTF-8 output");
+        assert_eq!(output, "\n");
+    }
+
+    #[test]
+    fn raw_output_preserves_trailing_newline_plus_record_newline() {
+        // jq -r prints the string contents then its own record newline.
+        let mut cmd =
+            Command::cargo_bin("jg").expect("Failed to find main binary");
+        let assert = cmd
+            .args(["-r", "s", "--no-path"])
+            .write_stdin(r#"{"s": "x\n"}"#)
+            .assert()
+            .success();
+        let output = String::from_utf8(assert.get_output().stdout.clone())
+            .expect("Invalid UTF-8 output");
+        assert_eq!(output, "x\n\n");
+    }
+
+    #[test]
+    fn raw_output_with_path_header() {
+        let mut cmd =
+            Command::cargo_bin("jg").expect("Failed to find main binary");
+        let assert = cmd
+            .args(["-r", "name", "--with-path"])
+            .write_stdin(r#"{"name": "Ada"}"#)
+            .assert()
+            .success();
+        let output = String::from_utf8(assert.get_output().stdout.clone())
+            .expect("Invalid UTF-8 output");
+        assert_eq!(output, "name:\nAda\n");
+    }
+
+    #[test]
+    fn raw_output_leaves_non_strings_as_json() {
+        let mut cmd =
+            Command::cargo_bin("jg").expect("Failed to find main binary");
+        let assert = cmd
+            .args(["-r", "*", "--no-path", "--compact"])
+            .write_stdin(r#"{"n": 42, "b": true, "o": {"k": "v"}}"#)
+            .assert()
+            .success();
+        let output = String::from_utf8(assert.get_output().stdout.clone())
+            .expect("Invalid UTF-8 output");
+        assert_eq!(output, "42\ntrue\n{\"k\":\"v\"}\n");
+    }
+
+    #[test]
+    fn raw_output_only_affects_top_level_strings() {
+        // A string nested inside a matched object keeps its JSON quoting.
+        let mut cmd =
+            Command::cargo_bin("jg").expect("Failed to find main binary");
+        let assert = cmd
+            .args(["-r", "user", "--no-path", "--compact"])
+            .write_stdin(r#"{"user": {"name": "Ada"}}"#)
+            .assert()
+            .success();
+        let output = String::from_utf8(assert.get_output().stdout.clone())
+            .expect("Invalid UTF-8 output");
+        assert_eq!(output, "{\"name\":\"Ada\"}\n");
+    }
+
+    // ==============================================================================
     // Path header display tests
     // ==============================================================================
 


### PR DESCRIPTION
The most-used jq flag, and the difference between jg being usable in
shell pipelines or not: `TOKEN=$(... | jg -r auth.token)` now yields
the bare string instead of a JSON-quoted one.

Semantics match jq -r: a matched value that IS a string prints its
decoded contents (real newlines for \n, no quotes, uncolored) followed
by the record newline; non-string values and strings nested inside
matched objects/arrays keep their JSON form.

write_colored_result gains a `raw` parameter (library-breaking; 0.10.0
alongside the other pending signature changes).

CLI tests: unquoting, escape decoding, empty string, trailing-newline
preservation, --with-path interaction, non-strings and nested strings
unchanged.


---

*This PR is one of a series from a full-repo review (each branch is independent off `main`). Where PRs touch the same files (`CHANGELOG.md`, `src/query/dfa.rs`, `src/main.rs`), conflicts are trivial - mostly CHANGELOG section concatenation - and I'm happy to rebase whichever land later.*
