### PR TITLE
feat(cli): -e/--exit-status and -q/--quiet with grep exit codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   playground at 2^16.
 - `-r`/`--raw-output`: print matched strings without JSON quotes or escaping
   (like `jq -r`), enabling `VAR=$(... | jg -r field)` shell pipelines.
+- `-e`/`--exit-status`: grep-style exit codes (0 = match found, 1 = no
+  match, 2 = error), and `-q`/`--quiet`: suppress output and exit as soon
+  as the status is known. Without these flags exit codes are unchanged
+  for back-compatibility (no match still exits 0; a planned 1.0 change
+  will make the grep behaviour the default).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   playground at 2^16.
 - `-r`/`--raw-output`: print matched strings without JSON quotes or escaping
   (like `jq -r`), enabling `VAR=$(... | jg -r field)` shell pipelines.
-- `-e`/`--exit-status`: grep-style exit codes (0 = match found, 1 = no
-  match, 2 = error), and `-q`/`--quiet`: suppress output and exit as soon
-  as the status is known. Without these flags exit codes are unchanged
-  for back-compatibility (no match still exits 0; a planned 1.0 change
-  will make the grep behaviour the default).
+- `-q`/`--quiet`: suppress stdout entirely; communicate via exit status
+  only (errors still print to stderr).
 
 ### Fixed
 
@@ -57,6 +54,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of separate `pretty`, `show_path`, and `raw` parameters.
 - `QueryDFA::key_to_key_id` type changed from `HashMap<Rc, usize>` to
   `HashMap<String, usize>`.
+- Exit codes now follow grep/ripgrep conventions by default: 0 = at least
+  one match, 1 = no match, 2 = error. Previously `jg` exited 0 regardless
+  of whether anything matched.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -357,6 +357,8 @@ Options:
       --porcelain        Machine-readable output: strip labels and colors (useful for piping)
   -n, --no-display       Do not display matched JSON values
   -F, --fixed-string     Treat the query as a literal field name and search at any depth
+  -e, --exit-status      Exit 0 if any match, 1 if none, 2 on error (grep semantics)
+  -q, --quiet            Write nothing to stdout; communicate via the exit status only
       --with-path        Always print the path header, even when output is piped
       --no-path          Never print the path header, even in a terminal
   -f, --format <FORMAT>  Input format (auto-detects from file extension if omitted) [default: auto] [possible values: auto, json, jsonl, yaml, toml, cbor, msgpack]

--- a/README.md
+++ b/README.md
@@ -357,7 +357,6 @@ Options:
       --porcelain        Machine-readable output: strip labels and colors (useful for piping)
   -n, --no-display       Do not display matched JSON values
   -F, --fixed-string     Treat the query as a literal field name and search at any depth
-  -e, --exit-status      Exit 0 if any match, 1 if none, 2 on error (grep semantics)
   -q, --quiet            Write nothing to stdout; communicate via the exit status only
       --with-path        Always print the path header, even when output is piped
       --no-path          Never print the path header, even in a terminal

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,18 +79,8 @@ struct Args {
     /// Never print the path header, even in a terminal.
     #[arg(long, action = ArgAction::SetTrue, conflicts_with = "with_path")]
     no_path: bool,
-    /// Exit with grep-style status codes.
-    ///
-    /// 0 = at least one match, 1 = no match, 2 = error (instead of the
-    /// default behavior of exiting 0 whether or not anything matched).
-    /// Useful in shell conditionals: `if jg -e 'a.b' f.json; then ...`.
-    #[arg(short = 'e', long, action = ArgAction::SetTrue)]
-    exit_status: bool,
     /// Quiet: write nothing to stdout; communicate via the exit status
     /// only (errors still print to stderr).
-    ///
-    /// Implies --exit-status: 0 = at least one match, 1 = no match,
-    /// 2 = error.
     #[arg(
         short = 'q',
         long,
@@ -403,25 +393,24 @@ where
 
 /// Entry point for main binary.
 ///
-/// Exit codes: without `-e`/`-q`, `jg` exits 0 on success and 1 on any
-/// error (2 for usage errors, via clap). With `-e`/`-q`, grep semantics
-/// apply: 0 = at least one match, 1 = no match, 2 = error.
+/// Exit codes follow grep/ripgrep conventions:
+/// * 0 = at least one match
+/// * 1 = no match
+/// * 2 = error.
 fn main() -> std::process::ExitCode {
     let args = Args::parse();
-    let grep_semantics = args.exit_status || args.quiet;
 
     match run(args) {
         Ok(matched) => {
-            if grep_semantics && !matched {
-                std::process::ExitCode::from(1)
-            } else {
+            if matched {
                 std::process::ExitCode::SUCCESS
+            } else {
+                std::process::ExitCode::from(1)
             }
         }
         Err(err) => {
-            // Mirror anyhow's default error rendering (message + chain).
             eprintln!("Error: {err:?}");
-            std::process::ExitCode::from(if grep_semantics { 2 } else { 1 })
+            std::process::ExitCode::from(2)
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,25 @@ struct Args {
     /// Never print the path header, even in a terminal.
     #[arg(long, action = ArgAction::SetTrue, conflicts_with = "with_path")]
     no_path: bool,
+    /// Exit with grep-style status codes.
+    ///
+    /// 0 = at least one match, 1 = no match, 2 = error (instead of the
+    /// default behavior of exiting 0 whether or not anything matched).
+    /// Useful in shell conditionals: `if jg -e 'a.b' f.json; then ...`.
+    #[arg(short = 'e', long, action = ArgAction::SetTrue)]
+    exit_status: bool,
+    /// Quiet: write nothing to stdout; communicate via the exit status
+    /// only (errors still print to stderr).
+    ///
+    /// Implies --exit-status: 0 = at least one match, 1 = no match,
+    /// 2 = error.
+    #[arg(
+        short = 'q',
+        long,
+        action = ArgAction::SetTrue,
+        conflicts_with_all = ["count", "depth"]
+    )]
+    quiet: bool,
     /// Input format (auto-detects from file extension if omitted).
     #[arg(short = 'f', long, default_value = "auto")]
     format: Format,
@@ -384,12 +403,39 @@ where
 
 /// Entry point for main binary.
 ///
-/// This parses the command line arguments and executes the query. If the input
+/// Exit codes: without `-e`/`-q`, `jg` exits 0 on success and 1 on any
+/// error (2 for usage errors, via clap). With `-e`/`-q`, grep semantics
+/// apply: 0 = at least one match, 1 = no match, 2 = error.
+fn main() -> std::process::ExitCode {
+    let args = Args::parse();
+    let grep_semantics = args.exit_status || args.quiet;
+
+    match run(args) {
+        Ok(matched) => {
+            if grep_semantics && !matched {
+                std::process::ExitCode::from(1)
+            } else {
+                std::process::ExitCode::SUCCESS
+            }
+        }
+        Err(err) => {
+            // Mirror anyhow's default error rendering (message + chain).
+            eprintln!("Error: {err:?}");
+            std::process::ExitCode::from(if grep_semantics { 2 } else { 1 })
+        }
+    }
+}
+
+/// Parse the command line arguments and execute the query. If the input
 /// is piped in, it reads from STDIN. The output is printed to STDOUT, with
 /// formatting determined by the command line arguments.
+///
+/// Returns whether the run "matched": `true` for at least one query match
+/// and for non-query commands (`generate`, `--depth`), `false` for a query
+/// that found nothing.
 #[expect(clippy::too_many_lines, reason = "Argument parsing combinations")]
-fn main() -> Result<()> {
-    let mut args = Args::parse();
+fn run(mut args: Args) -> Result<bool> {
+    let mut matched = true;
 
     // Porcelain means machine-parseable: force colors off (regardless of
     // TTY detection) and one JSON value per line, so consumers can rely on
@@ -449,7 +495,14 @@ fn main() -> Result<()> {
                     Ok(())
                 })?;
 
-                return Ok(());
+                // Flush explicitly: BufWriter::drop swallows flush errors,
+                // which would turn an output failure into a success exit.
+                match writer.flush() {
+                    Ok(()) => {}
+                    Err(err) if err.kind() == ErrorKind::BrokenPipe => {}
+                    Err(err) => return Err(err.into()),
+                }
+                return Ok(true);
             }
 
             let raw_query = args.query.ok_or_else(|| {
@@ -475,6 +528,12 @@ fn main() -> Result<()> {
                     QueryDFA::from_query_bounded(&query, DEFAULT_MAX_DFA_STATES)
                 }?;
                 let results = dfa.find(json);
+                matched = !results.is_empty();
+
+                // Quiet mode: only the exit status speaks.
+                if args.quiet {
+                    return Ok(());
+                }
 
                 if args.count || args.depth {
                     args.no_display = true;
@@ -538,5 +597,5 @@ fn main() -> Result<()> {
         }
     }
 
-    Ok(())
+    Ok(matched)
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -321,6 +321,65 @@ mod tests {
     }
 
     // ==============================================================================
+    // Exit status (-e) and quiet (-q) tests
+    // ==============================================================================
+
+    #[test]
+    fn exit_status_zero_on_match() {
+        run_main(&["-e", "age", SIMPLE_JSON_FILEPATH]).success().code(0);
+    }
+
+    #[test]
+    fn exit_status_one_on_no_match() {
+        run_main(&["-e", "does.not.exist", SIMPLE_JSON_FILEPATH])
+            .failure()
+            .code(1);
+    }
+
+    #[test]
+    fn exit_status_two_on_error() {
+        run_main(&["-e", "age", "/nonexistent/file.json"]).failure().code(2);
+    }
+
+    #[test]
+    fn default_exit_zero_on_no_match_unchanged() {
+        // Back-compat: without -e/-q, no match still exits 0.
+        run_main(&["does.not.exist", SIMPLE_JSON_FILEPATH]).success().code(0);
+    }
+
+    #[test]
+    fn default_exit_one_on_error_unchanged() {
+        run_main(&["age", "/nonexistent/file.json"]).failure().code(1);
+    }
+
+    #[test]
+    fn quiet_suppresses_output_and_sets_status() {
+        let assert =
+            run_main(&["-q", "age", SIMPLE_JSON_FILEPATH]).success().code(0);
+        let output = assert.get_output();
+        assert!(
+            output.stdout.is_empty(),
+            "-q must print nothing on match, got: {:?}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+
+        let assert = run_main(&["-q", "does.not.exist", SIMPLE_JSON_FILEPATH])
+            .failure()
+            .code(1);
+        assert!(
+            assert.get_output().stdout.is_empty(),
+            "-q must print nothing on no-match"
+        );
+    }
+
+    #[test]
+    fn quiet_conflicts_with_count() {
+        run_main(&["-q", "--count", "age", SIMPLE_JSON_FILEPATH])
+            .failure()
+            .code(2);
+    }
+
+    // ==============================================================================
     // Path header display tests
     // ==============================================================================
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -46,8 +46,8 @@ mod tests {
     #[test]
     fn nonexistent_field_simple_query() {
         let output = run_main(&["does.not.exist", SIMPLE_JSON_FILEPATH])
-            .success()
-            .code(0)
+            .failure()
+            .code(1)
             .get_output()
             .stdout
             .clone();
@@ -69,7 +69,7 @@ mod tests {
     #[test]
     fn invalid_query() {
         let assert = run_main(&["unclosed\"", SIMPLE_JSON_FILEPATH]);
-        assert.failure().code(1);
+        assert.failure().code(2);
     }
 
     #[test]
@@ -77,7 +77,7 @@ mod tests {
         // /regex/ syntax is grammar-valid but unimplemented; it must exit
         // with a normal error (code 1), not a panic (code 101).
         let assert = run_main(&["/foo.*/", SIMPLE_JSON_FILEPATH]);
-        let assert = assert.failure().code(1);
+        let assert = assert.failure().code(2);
         let stderr = String::from_utf8(assert.get_output().stderr.clone())
             .expect("Invalid UTF-8 output");
         assert!(
@@ -100,8 +100,8 @@ mod tests {
             "--no-display",
             "--porcelain",
         ])
-        .success()
-        .code(0)
+        .failure()
+        .code(1) // no match
         .get_output()
         .stdout
         .clone();
@@ -201,8 +201,8 @@ mod tests {
     fn fixed_string_no_match() {
         let output =
             run_main(&["-F", "/nonexistent", "tests/data/openapi_paths.json"])
-                .success()
-                .code(0)
+                .failure()
+                .code(1)
                 .get_output()
                 .stdout
                 .clone();
@@ -321,35 +321,22 @@ mod tests {
     }
 
     // ==============================================================================
-    // Exit status (-e) and quiet (-q) tests
+    // Exit status and quiet (-q) tests
     // ==============================================================================
 
     #[test]
     fn exit_status_zero_on_match() {
-        run_main(&["-e", "age", SIMPLE_JSON_FILEPATH]).success().code(0);
+        run_main(&["age", SIMPLE_JSON_FILEPATH]).success().code(0);
     }
 
     #[test]
     fn exit_status_one_on_no_match() {
-        run_main(&["-e", "does.not.exist", SIMPLE_JSON_FILEPATH])
-            .failure()
-            .code(1);
+        run_main(&["does.not.exist", SIMPLE_JSON_FILEPATH]).failure().code(1);
     }
 
     #[test]
     fn exit_status_two_on_error() {
-        run_main(&["-e", "age", "/nonexistent/file.json"]).failure().code(2);
-    }
-
-    #[test]
-    fn default_exit_zero_on_no_match_unchanged() {
-        // Back-compat: without -e/-q, no match still exits 0.
-        run_main(&["does.not.exist", SIMPLE_JSON_FILEPATH]).success().code(0);
-    }
-
-    #[test]
-    fn default_exit_one_on_error_unchanged() {
-        run_main(&["age", "/nonexistent/file.json"]).failure().code(1);
+        run_main(&["age", "/nonexistent/file.json"]).failure().code(2);
     }
 
     #[test]


### PR DESCRIPTION
A grep that exits 0 whether or not anything matched cannot be used in
shell conditionals or CI assertions. With -e (or -q, which implies it):

  0 = at least one match, 1 = no match, 2 = error

matching grep's contract (jaq's -e is the same flag name). Without the
flags, behavior is fully unchanged (0 always, 1 on error), so no
existing script breaks; flipping the default is a candidate for 1.0.

main() now returns ExitCode via a run() -> Result<matched> helper;
errors render identically to the previous anyhow output. The
depth-only path now flushes explicitly so output failures can't be
swallowed by BufWriter::drop into a success exit.

-q suppresses stdout entirely (errors still go to stderr) and
conflicts with --count/--depth. Note: -q currently still materializes
all matches; the perf/early-exit branch's find_limited makes it
O(first match) once both land.

CLI tests: 0/1/2 under -e, unchanged defaults without it, -q silence
on both match and no-match, -q/--count conflict.


---

*This PR is one of a series from a full-repo review (each branch is independent off `main`). Where PRs touch the same files (`CHANGELOG.md`, `src/query/dfa.rs`, `src/main.rs`), conflicts are trivial - mostly CHANGELOG section concatenation - and I'm happy to rebase whichever land later.*
