### PR TITLE
chore(tests): delete tests/lib.rs so the CLI suite runs once, not twice

### DIFF
--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,2 +1,0 @@
-//! Integration test suite for `rq`.
-mod cli;


### PR DESCRIPTION
tests/lib.rs declared `mod cli;` while Cargo.toml also has an explicit
[[test]] target for tests/cli.rs, so cargo autodiscovered lib.rs as a
second integration-test binary compiling and executing the entire
~40-subprocess CLI suite twice per `cargo test`. (Its doc comment also
still referenced "rq", the project's pre-rename name.)

Verified: the suite now runs once; no tests lost.