### PR TITLE
fix(cli): make --porcelain honest - force colors off, imply --compact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Array index `[18446744073709551615]` (`usize::MAX`) no longer overflows
   (panic in debug builds, silent wrap in release); it now matches nothing,
   which is correct since an element at that index cannot exist.
+- `--porcelain` now does what its help text says for match output too:
+  colors are forced off (previously still colored on a TTY) and
+  `--compact` is implied, so output is one machine-parseable JSON value
+  per line. Previously only the `--count`/`--depth` labels were
+  affected.
 
 ### Breaking
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,8 @@ struct Args {
     /// Display depth of the input document.
     #[arg(long, action = ArgAction::SetTrue, conflicts_with = "count")]
     depth: bool,
-    /// Machine-readable output: strip labels and colors (useful for piping).
+    /// Machine-readable output: strip labels and colors, print one JSON
+    /// value per line (implies --compact).
     #[arg(long, action = ArgAction::SetTrue)]
     porcelain: bool,
     /// Do not display matched JSON values.
@@ -383,6 +384,16 @@ where
 #[expect(clippy::too_many_lines, reason = "Argument parsing combinations")]
 fn main() -> Result<()> {
     let mut args = Args::parse();
+
+    // Porcelain means machine-parseable: force colors off (regardless of
+    // TTY detection) and one JSON value per line, so consumers can rely on
+    // the output shape. Previously only the --count/--depth labels were
+    // affected, while match output stayed colored (on a TTY) and
+    // multi-line pretty-printed.
+    if args.porcelain {
+        colored::control::set_override(false);
+        args.compact = true;
+    }
 
     match args.command {
         Some(Commands::Generate(cmd)) => match cmd {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -216,6 +216,50 @@ mod tests {
     }
 
     // ==============================================================================
+    // Porcelain output tests
+    // ==============================================================================
+
+    #[test]
+    fn porcelain_match_output_is_compact_json_lines() {
+        // --porcelain must imply --compact: one JSON value per line, no
+        // pretty-printing, parseable by line-oriented consumers.
+        let mut cmd =
+            Command::cargo_bin("jg").expect("Failed to find main binary");
+        let assert = cmd
+            .args(["--porcelain", "--no-path", "users[*]"])
+            .write_stdin(r#"{"users": [{"a": 1}, {"b": 2}]}"#)
+            .assert()
+            .success();
+        let output = String::from_utf8(assert.get_output().stdout.clone())
+            .expect("Invalid UTF-8 output");
+        assert_eq!(output, "{\"a\":1}\n{\"b\":2}\n");
+        for line in output.lines() {
+            serde_json::from_str::<Value>(line)
+                .expect("each porcelain line must be valid JSON");
+        }
+    }
+
+    #[test]
+    fn porcelain_output_has_no_ansi_escapes() {
+        // Even if color would otherwise be forced on, porcelain wins.
+        let mut cmd =
+            Command::cargo_bin("jg").expect("Failed to find main binary");
+        let assert = cmd
+            .args(["--porcelain", "--with-path", "a"])
+            .env("CLICOLOR_FORCE", "1")
+            .write_stdin(r#"{"a": {"nested": true}}"#)
+            .assert()
+            .success();
+        let output = String::from_utf8(assert.get_output().stdout.clone())
+            .expect("Invalid UTF-8 output");
+        assert!(
+            !output.contains('\u{1b}'),
+            "porcelain output must not contain ANSI escapes: {output:?}"
+        );
+        assert_eq!(output, "a:\n{\"nested\":true}\n");
+    }
+
+    // ==============================================================================
     // Path header display tests
     // ==============================================================================
 


### PR DESCRIPTION
--porcelain's help promised "strip labels and colors" but only the
--count/--depth label prefixes were affected: match output was still
colored when stdout was a TTY (it only *looked* right in pipes because
the `colored` crate auto-disables there) and was pretty-printed
multi-line JSON with no record separator, which no line-oriented
consumer can parse.

Porcelain now forces colors off via colored::control::set_override
(beating even CLICOLOR_FORCE) and implies --compact, so match output
is exactly one JSON value per line.

Tests: porcelain match output is byte-exact compact JSON lines (each
line re-parsed as JSON), and contains no ANSI escapes even with
CLICOLOR_FORCE=1 and --with-path.