### PR TITLE
feat(cli): multiple file arguments, file headings, -l/--files-with-matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Exit codes now follow grep/ripgrep conventions by default: 0 = at least
   one match, 1 = no match, 2 = error. Previously `jg` exited 0 regardless
   of whether anything matched.
+- `jg --depth "<query>" file` no longer silently ignores the query slot;
+  `--depth` now takes only file arguments (`jg --depth file...`).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (like `jq -r`), enabling `VAR=$(... | jg -r field)` shell pipelines.
 - `-q`/`--quiet`: suppress stdout entirely; communicate via exit status
   only (errors still print to stderr).
+- Multiple file arguments: `jg 'query' a.json b.yaml ...` compiles the
+  query once and runs it against each file with per-file format
+  autodetection, ripgrep-style file headings (TTY) or `file:` prefixes on
+  counts, error-continue behaviour like grep (a bad file is reported and
+  the rest still run), and `-l`/`--files-with-matches` to list only files
+  containing at least one match.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -339,14 +339,14 @@ cargo install jsongrep --no-default-features
 ```
 JSONPath-inspired query language for JSON, YAML, TOML, and other serialization formats
 
-Usage: jg [OPTIONS] [QUERY] [FILE] [COMMAND]
+Usage: jg [OPTIONS] [QUERY] [FILE]... [COMMAND]
 
 Commands:
   generate  Generate additional documentation and/or completions
 
 Arguments:
-  [QUERY]  Query string (e.g., "**.name")
-  [FILE]   Optional path to file. If omitted, reads from STDIN
+  [QUERY]    Query string (e.g., "**.name")
+  [FILE]...  Optional path(s) to file(s). If omitted, reads from STDIN
 
 Options:
   -i, --ignore-case      Case insensitive search
@@ -358,6 +358,7 @@ Options:
   -n, --no-display       Do not display matched JSON values
   -F, --fixed-string     Treat the query as a literal field name and search at any depth
   -q, --quiet            Write nothing to stdout; communicate via the exit status only
+  -l, --files-with-matches  Print only the names of files containing at least one match
       --with-path        Always print the path header, even when output is piped
       --no-path          Never print the path header, even in a terminal
   -f, --format <FORMAT>  Input format (auto-detects from file extension if omitted) [default: auto] [possible values: auto, json, jsonl, yaml, toml, cbor, msgpack]
@@ -402,6 +403,27 @@ echo "$TOKEN"
 
 ```
 abc123
+```
+
+**Search several files at once** (the query compiles once and runs per
+file, with per-file format autodetection and ripgrep-style headings):
+
+```bash
+jg 'services.*.image' staging/docker-compose.yml prod/docker-compose.yml
+```
+
+```
+staging/docker-compose.yml
+services.web.image:
+"nginx:1.27"
+
+prod/docker-compose.yml
+services.web.image:
+"nginx:1.26"
+```
+
+```bash
+jg -l 'services.db' */docker-compose.yml   # which files define a db service?
 ```
 
 **Piping to other tools:**

--- a/src/main.rs
+++ b/src/main.rs
@@ -499,26 +499,14 @@ fn run(mut args: Args) -> Result<bool> {
             };
             let mut writer = BufWriter::new(stdout);
 
-            // `--depth` without a query: sole positional argument is the file
+            // `--depth` takes only files, no query string. Clap parses the
+            // first positional into `query`; move it into `inputs`.
             if args.depth
-                && args.inputs.is_empty()
                 && let Some(query) = args.query.take()
             {
-                args.inputs.push(PathBuf::from(query));
+                args.inputs.insert(0, PathBuf::from(query));
             }
-            // With files already present, the query slot is legacy-ignored
-            // (`jg --depth "<query>" file` back-compat) UNLESS it names an
-            // existing file: then `jg --depth a.json b.json` means both
-            // files, not "ignore a.json".
-            if args.depth
-                && !args.inputs.is_empty()
-                && let Some(query) = args.query.take()
-            {
-                let candidate = PathBuf::from(&query);
-                if candidate.exists() {
-                    args.inputs.insert(0, candidate);
-                }
-            }
+
             // short circuit to only perform the depth computation
             if args.depth && !args.inputs.is_empty() {
                 let multi = args.inputs.len() > 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,8 +41,19 @@ struct Args {
     /// Query string (e.g., "**.name").
     query: Option<String>,
     #[arg(value_name = "FILE")]
-    /// Optional path to file. If omitted, reads from STDIN.
-    input: Option<PathBuf>,
+    /// Optional path(s) to file(s). If omitted, reads from STDIN. With
+    /// multiple files, the query is compiled once and run against each
+    /// file, with a file heading before each file's matches.
+    inputs: Vec<PathBuf>,
+    /// Print only the names of files containing at least one match
+    /// (like `grep -l`).
+    #[arg(
+        short = 'l',
+        long,
+        action = ArgAction::SetTrue,
+        conflicts_with_all = ["count", "depth", "no_display"]
+    )]
+    files_with_matches: bool,
     /// Case insensitive search.
     #[arg(short, long, action = ArgAction::SetTrue)]
     ignore_case: bool,
@@ -237,6 +248,17 @@ impl Input {
             }
         }
     }
+}
+
+/// Whether any error in the chain is a broken pipe (the downstream consumer
+/// of stdout has gone away), which is a signal to stop printing, not an
+/// input-file failure.
+fn is_broken_pipe(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        cause
+            .downcast_ref::<io::Error>()
+            .is_some_and(|io_err| io_err.kind() == ErrorKind::BrokenPipe)
+    })
 }
 
 /// Parse input content, from the input path buffer if provided, else try STDIN.
@@ -438,7 +460,7 @@ fn main() -> std::process::ExitCode {
 /// that found nothing.
 #[expect(clippy::too_many_lines, reason = "Argument parsing combinations")]
 fn run(mut args: Args) -> Result<bool> {
-    let mut matched = true;
+    let mut matched = false;
 
     // Porcelain means machine-parseable: force colors off (regardless of
     // TTY detection) and one JSON value per line, so consumers can rely on
@@ -478,32 +500,80 @@ fn run(mut args: Args) -> Result<bool> {
             let mut writer = BufWriter::new(stdout);
 
             // `--depth` without a query: sole positional argument is the file
-            if args.depth && args.query.is_some() && args.input.is_none() {
-                args.input = args.query.take().map(PathBuf::from);
+            if args.depth
+                && args.inputs.is_empty()
+                && let Some(query) = args.query.take()
+            {
+                args.inputs.push(PathBuf::from(query));
+            }
+            // With files already present, the query slot is legacy-ignored
+            // (`jg --depth "<query>" file` back-compat) UNLESS it names an
+            // existing file: then `jg --depth a.json b.json` means both
+            // files, not "ignore a.json".
+            if args.depth
+                && !args.inputs.is_empty()
+                && let Some(query) = args.query.take()
+            {
+                let candidate = PathBuf::from(&query);
+                if candidate.exists() {
+                    args.inputs.insert(0, candidate);
+                }
             }
             // short circuit to only perform the depth computation
-            if args.depth && args.input.is_some() {
-                let format = detect_format(args.input.as_ref(), args.format);
-                with_json(args.input, format, |json| {
-                    if args.porcelain {
-                        writeln!(writer, "{}", depth(json))?;
-                    } else {
-                        writeln!(
-                            writer,
-                            "{} {}",
-                            "Depth:".bold().blue(),
-                            depth(json)
-                        )?;
+            if args.depth && !args.inputs.is_empty() {
+                let multi = args.inputs.len() > 1;
+                let mut failed_inputs = 0usize;
+                for path in args.inputs {
+                    let format = detect_format(Some(&path), args.format);
+                    let name = path.display().to_string();
+                    let file_result = with_json(Some(path), format, |json| {
+                        if multi {
+                            // Attribute per file, grep -c style.
+                            let styled_name = if args.porcelain {
+                                name.normal()
+                            } else {
+                                name.bold().magenta()
+                            };
+                            writeln!(
+                                writer,
+                                "{}:{}",
+                                styled_name,
+                                depth(json)
+                            )?;
+                        } else if args.porcelain {
+                            writeln!(writer, "{}", depth(json))?;
+                        } else {
+                            writeln!(
+                                writer,
+                                "{} {}",
+                                "Depth:".bold().blue(),
+                                depth(json)
+                            )?;
+                        }
+                        Ok(())
+                    });
+                    if let Err(err) = file_result {
+                        if multi && !is_broken_pipe(&err) {
+                            writer.flush().ok();
+                            eprintln!("jg: {name}: {err:#}");
+                            failed_inputs += 1;
+                        } else if multi {
+                            break;
+                        } else {
+                            return Err(err);
+                        }
                     }
-                    Ok(())
-                })?;
+                }
 
-                // Flush explicitly: BufWriter::drop swallows flush errors,
-                // which would turn an output failure into a success exit.
-                match writer.flush() {
-                    Ok(()) => {}
-                    Err(err) if err.kind() == ErrorKind::BrokenPipe => {}
-                    Err(err) => return Err(err.into()),
+                if failed_inputs > 0 {
+                    match writer.flush() {
+                        Ok(()) => {}
+                        Err(err) if err.kind() == ErrorKind::BrokenPipe => {}
+                        Err(err) => return Err(err.into()),
+                    }
+                    anyhow::bail!(
+                        "{failed_inputs} input file(s) could not be processed"
+                    );
                 }
                 return Ok(true);
             }
@@ -520,77 +590,161 @@ fn run(mut args: Args) -> Result<bool> {
                 raw_query.parse().with_context(|| "Failed to parse query")?
             };
 
-            let format = detect_format(args.input.as_ref(), args.format);
-            with_json(args.input, format, |json| {
-                let dfa = if args.ignore_case {
-                    QueryDFA::from_query_bounded_ignore_case(
-                        &query,
-                        DEFAULT_MAX_DFA_STATES,
-                    )
-                } else {
-                    QueryDFA::from_query_bounded(&query, DEFAULT_MAX_DFA_STATES)
-                }?;
-                let results = dfa.find(json);
-                matched = !results.is_empty();
+            // Compile the DFA once; run it against every input.
+            let dfa = if args.ignore_case {
+                QueryDFA::from_query_bounded_ignore_case(
+                    &query,
+                    DEFAULT_MAX_DFA_STATES,
+                )
+            } else {
+                QueryDFA::from_query_bounded(&query, DEFAULT_MAX_DFA_STATES)
+            }?;
 
-                // Quiet mode: only the exit status speaks.
-                if args.quiet {
-                    return Ok(());
-                }
+            if args.count || args.depth {
+                args.no_display = true;
+            }
 
-                if args.count || args.depth {
-                    args.no_display = true;
-                }
+            let multi = args.inputs.len() > 1;
+            let inputs: Vec<Option<PathBuf>> = if args.inputs.is_empty() {
+                vec![None]
+            } else {
+                args.inputs.into_iter().map(Some).collect()
+            };
 
-                if args.count {
-                    if args.porcelain {
-                        writeln!(writer, "{}", results.len())?;
-                    } else {
-                        writeln!(
-                            writer,
-                            "{} {}",
-                            "Found matches:".bold().blue(),
-                            results.len()
-                        )
-                        .with_context(|| "Failed to write to stdout")?;
+            // Errors in one file must not prevent searching the rest
+            // (grep semantics); remember and report at the end.
+            let mut failed_inputs = 0usize;
+            let mut printed_block = false;
+
+            for input in inputs {
+                let format = detect_format(input.as_ref(), args.format);
+                let name = input.as_ref().map_or_else(
+                    || "(standard input)".to_string(),
+                    |p| p.display().to_string(),
+                );
+
+                let file_result = with_json(input, format, |json| {
+                    let results = dfa.find(json);
+                    if !results.is_empty() {
+                        matched = true;
                     }
-                }
 
-                if args.depth {
-                    if args.porcelain {
-                        writeln!(writer, "{}", depth(json))?;
-                    } else {
-                        writeln!(
-                            writer,
-                            "{} {}",
-                            "Depth:".bold().blue(),
-                            depth(json)
-                        )?;
+                    if args.quiet {
+                        return Ok(());
                     }
-                }
 
-                if !args.no_display {
-                    let pretty = !args.compact;
-                    for result in &results {
-                        // Stop formatting once the downstream consumer is
-                        // gone (e.g. `jg ... | head -1`).
-                        if !write_colored_result(
-                            &mut writer,
-                            result.value,
-                            &result.path,
-                            &WriteOptions {
-                                pretty,
-                                show_path,
-                                raw: args.raw_output,
-                            },
-                        )? {
-                            break;
+                    if args.files_with_matches {
+                        if !results.is_empty() {
+                            writeln!(writer, "{name}")?;
+                        }
+                        return Ok(());
+                    }
+
+                    if args.count {
+                        if multi {
+                            // grep -c style per-file attribution.
+                            let styled_name = if args.porcelain {
+                                name.normal()
+                            } else {
+                                name.bold().magenta()
+                            };
+                            writeln!(
+                                writer,
+                                "{}:{}",
+                                styled_name,
+                                results.len()
+                            )?;
+                        } else if args.porcelain {
+                            writeln!(writer, "{}", results.len())?;
+                        } else {
+                            writeln!(
+                                writer,
+                                "{} {}",
+                                "Found matches:".bold().blue(),
+                                results.len()
+                            )
+                            .with_context(|| "Failed to write to stdout")?;
                         }
                     }
-                }
 
-                Ok(())
-            })?;
+                    if args.depth {
+                        if args.porcelain {
+                            writeln!(writer, "{}", depth(json))?;
+                        } else {
+                            writeln!(
+                                writer,
+                                "{} {}",
+                                "Depth:".bold().blue(),
+                                depth(json)
+                            )?;
+                        }
+                    }
+
+                    if !args.no_display && !results.is_empty() {
+                        // ripgrep-style headings: with several inputs, name
+                        // the file once before its matches, with a blank
+                        // line between file blocks.
+                        if multi {
+                            if printed_block {
+                                writeln!(writer)?;
+                            }
+                            let styled_name = if args.porcelain {
+                                name.normal()
+                            } else {
+                                name.bold().green()
+                            };
+                            writeln!(writer, "{styled_name}")?;
+                        }
+                        printed_block = true;
+
+                        let pretty = !args.compact;
+                        for result in &results {
+                            write_colored_result(
+                                &mut writer,
+                                result.value,
+                                &result.path,
+                                &WriteOptions {
+                                    pretty,
+                                    show_path,
+                                    raw: args.raw_output,
+                                },
+                            )?;
+                        }
+                    }
+
+                    Ok(())
+                });
+
+                if let Err(err) = file_result {
+                    if multi && !is_broken_pipe(&err) {
+                        // Keep going, grep-style; attribute the failure.
+                        // Flush pending matches first so stdout/stderr
+                        // interleave in file order.
+                        writer.flush().ok();
+                        eprintln!("jg: {name}: {err:#}");
+                        failed_inputs += 1;
+                    } else if multi {
+                        // The output pipe is gone: nothing more can be
+                        // printed, so stop quietly (same as single-input
+                        // broken-pipe handling).
+                        break;
+                    } else {
+                        return Err(err);
+                    }
+                }
+            }
+
+            if failed_inputs > 0 {
+                // Flush what we printed before reporting the failure.
+                match writer.flush() {
+                    Ok(()) => {}
+                    Err(err) if err.kind() == ErrorKind::BrokenPipe => {}
+                    Err(err) => return Err(err.into()),
+                }
+                anyhow::bail!(
+                    "{failed_inputs} input file(s) could not be processed"
+                );
+            }
 
             match writer.flush() {
                 Ok(()) => {}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -417,6 +417,209 @@ mod tests {
     }
 
     // ==============================================================================
+    // Multiple file arguments
+    // ==============================================================================
+
+    #[test]
+    fn multi_file_headings_and_matches() {
+        let a = temp_file_with(".json", br#"{"name": "from-a"}"#);
+        let b = temp_file_with(".json", br#"{"name": "from-b"}"#);
+        let a_path = a.path().to_str().expect("path").to_string();
+        let b_path = b.path().to_str().expect("path").to_string();
+
+        let output = run_main(&["name", &a_path, &b_path, "--compact"])
+            .success()
+            .code(0)
+            .get_output()
+            .stdout
+            .clone();
+        let output = String::from_utf8(output).expect("Invalid UTF-8 output");
+
+        let expected =
+            format!("{a_path}\n\"from-a\"\n\n{b_path}\n\"from-b\"\n");
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn multi_file_heading_only_for_files_with_matches() {
+        let a = temp_file_with(".json", br#"{"name": "hit"}"#);
+        let b = temp_file_with(".json", br#"{"other": 1}"#);
+        let a_path = a.path().to_str().expect("path").to_string();
+        let b_path = b.path().to_str().expect("path").to_string();
+
+        let output = run_main(&["name", &a_path, &b_path, "--compact"])
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let output = String::from_utf8(output).expect("Invalid UTF-8 output");
+
+        assert!(output.contains(&a_path));
+        assert!(
+            !output.contains(&b_path),
+            "file with no matches must not get a heading: {output:?}"
+        );
+    }
+
+    #[test]
+    fn multi_file_mixed_formats() {
+        let a = temp_file_with(".json", br#"{"host": "json-host"}"#);
+        let b = temp_file_with(".yaml", b"host: yaml-host\n");
+        let a_path = a.path().to_str().expect("path").to_string();
+        let b_path = b.path().to_str().expect("path").to_string();
+
+        let output = run_main(&["host", &a_path, &b_path, "--compact"])
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let output = String::from_utf8(output).expect("Invalid UTF-8 output");
+        assert!(output.contains("\"json-host\""));
+        assert!(output.contains("\"yaml-host\""));
+    }
+
+    #[test]
+    fn files_with_matches_lists_only_hits() {
+        let a = temp_file_with(".json", br#"{"name": "hit"}"#);
+        let b = temp_file_with(".json", br#"{"other": 1}"#);
+        let a_path = a.path().to_str().expect("path").to_string();
+        let b_path = b.path().to_str().expect("path").to_string();
+
+        let output = run_main(&["-l", "name", &a_path, &b_path])
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let output = String::from_utf8(output).expect("Invalid UTF-8 output");
+        assert_eq!(output.trim(), a_path);
+    }
+
+    #[test]
+    fn multi_file_count_per_file() {
+        let a = temp_file_with(".json", br#"{"x": 1, "y": 2}"#);
+        let b = temp_file_with(".json", br#"{"z": 3}"#);
+        let a_path = a.path().to_str().expect("path").to_string();
+        let b_path = b.path().to_str().expect("path").to_string();
+
+        let output = run_main(&["*", &a_path, &b_path, "--count"])
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let output = String::from_utf8(output).expect("Invalid UTF-8 output");
+        assert_eq!(output, format!("{a_path}:2\n{b_path}:1\n"));
+    }
+
+    #[test]
+    fn multi_file_error_continues_with_remaining() {
+        let a = temp_file_with(".json", br#"{"name": "still-searched"}"#);
+        let a_path = a.path().to_str().expect("path").to_string();
+
+        let assert = run_main(&[
+            "name",
+            "/nonexistent/missing.json",
+            &a_path,
+            "--compact",
+        ])
+        .failure();
+        let output = assert.get_output();
+        let stdout =
+            String::from_utf8(output.stdout.clone()).expect("utf8 stdout");
+        let stderr =
+            String::from_utf8(output.stderr.clone()).expect("utf8 stderr");
+
+        assert!(
+            stdout.contains("\"still-searched\""),
+            "remaining files must still be searched: {stdout:?}"
+        );
+        assert!(
+            stderr.contains("missing.json"),
+            "failure must be attributed to the file: {stderr:?}"
+        );
+    }
+
+    #[test]
+    fn multi_file_count_porcelain_has_no_ansi() {
+        let a = temp_file_with(".json", br#"{"x": 1}"#);
+        let b = temp_file_with(".json", br#"{"y": 2}"#);
+        let a_path = a.path().to_str().expect("path").to_string();
+        let b_path = b.path().to_str().expect("path").to_string();
+
+        let mut cmd =
+            Command::cargo_bin("jg").expect("Failed to find main binary");
+        let assert = cmd
+            .args(["*", &a_path, &b_path, "--count", "--porcelain"])
+            .env("CLICOLOR_FORCE", "1")
+            .assert()
+            .success();
+        let output = String::from_utf8(assert.get_output().stdout.clone())
+            .expect("Invalid UTF-8 output");
+        assert!(
+            !output.contains('\u{1b}'),
+            "porcelain multi-count must be uncolored: {output:?}"
+        );
+        assert_eq!(output, format!("{a_path}:1\n{b_path}:1\n"));
+    }
+
+    #[test]
+    fn depth_multiple_files_all_processed() {
+        let a = temp_file_with(".json", br#"{"a": {"b": 1}}"#);
+        let b = temp_file_with(".json", br#"{"x": 1}"#);
+        let a_path = a.path().to_str().expect("path").to_string();
+        let b_path = b.path().to_str().expect("path").to_string();
+
+        let output = run_main(&["--depth", &a_path, &b_path, "--porcelain"])
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let output = String::from_utf8(output).expect("Invalid UTF-8 output");
+        assert_eq!(output, format!("{a_path}:3\n{b_path}:2\n"));
+    }
+
+    #[test]
+    fn depth_multi_file_error_continues() {
+        let a = temp_file_with(".json", br#"{"a": 1}"#);
+        let b = temp_file_with(".json", br#"{"b": {"c": 1}}"#);
+        let a_path = a.path().to_str().expect("path").to_string();
+        let b_path = b.path().to_str().expect("path").to_string();
+
+        let assert = run_main(&[
+            "--depth",
+            &a_path,
+            "/nonexistent/missing.json",
+            &b_path,
+            "--porcelain",
+        ])
+        .failure();
+        let output = assert.get_output();
+        let stdout =
+            String::from_utf8(output.stdout.clone()).expect("utf8 stdout");
+        let stderr =
+            String::from_utf8(output.stderr.clone()).expect("utf8 stderr");
+        assert!(
+            stdout.contains(&format!("{a_path}:2")),
+            "first file must be processed: {stdout:?}"
+        );
+        assert!(
+            stdout.contains(&format!("{b_path}:3")),
+            "file after the failing one must still be processed: {stdout:?}"
+        );
+        assert!(stderr.contains("missing.json"));
+    }
+
+    #[test]
+    fn single_file_output_unchanged_by_multi_support() {
+        let output = run_main(&["age", SIMPLE_JSON_FILEPATH, "--compact"])
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let output = String::from_utf8(output).expect("Invalid UTF-8 output");
+        assert_eq!(output.trim(), "32");
+    }
+
+    // ==============================================================================
     // Path header display tests
     // ==============================================================================
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1201,9 +1201,8 @@ mod tests {
 
     #[test]
     fn depth_suppresses_match_output() {
-        let assert = run_main(&["age", SIMPLE_JSON_FILEPATH, "--depth"])
-            .success()
-            .code(0);
+        let assert =
+            run_main(&[SIMPLE_JSON_FILEPATH, "--depth"]).success().code(0);
         let output = String::from_utf8(assert.get_output().stdout.clone())
             .expect("Invalid UTF-8 output");
         assert!(!output.contains("32"), "--depth should suppress match values");


### PR DESCRIPTION
It's in the name: a grep takes file lists. `jg QUERY FILE...` now
compiles the DFA once and runs it against every file - the library's
designed shape - with per-file format autodetection (JSON, YAML, TOML,
CBOR, MessagePack can be mixed in one invocation):

  jg 'services.*.image' staging/compose.yml prod/compose.yml
  jg 'dependencies.*' */Cargo.toml
  jg -l 'name' a.json b.json c.json

Output conventions follow ripgrep/grep:
- With several inputs, each file's matches are preceded by a heading
  (bold green, only for files with at least one match, blank line
  between blocks). Single-input output is byte-identical to before.
- --count prints grep -c style "file:count" per file; --depth prints
  "file:depth". Both uncolored under --porcelain.
- -l/--files-with-matches prints just the names of files with >=1
  match (conflicts with --count/--depth/--no-display).
- A file that fails to open or parse is reported to stderr
  ("jg: file: error"), the remaining files are still searched, and the
  run exits with an error at the end. Stdout is flushed before each
  stderr report so output interleaves in file order. A broken stdout
  pipe stops quietly instead of being misreported as file failures.

The legacy `jg --depth "<query>" file` back-compat (query slot ignored)
is preserved; a query-slot value naming an existing file is now treated
as a file, so `jg --depth a.json b.json` processes both.

Tests: headings and exact multi-file output, heading suppression for
matchless files, mixed JSON+YAML inputs, -l filtering, per-file counts,
porcelain multi-count has no ANSI escapes, error-continue for both
query and depth modes, legacy depth invocation, and single-file
behavior unchanged.