### PR TITLE
fix(parser): decode UTF-16 surrogate pairs in quoted fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--compact` is implied, so output is one machine-parseable JSON value
   per line. Previously only the `--count`/`--depth` labels were
   affected.
+- Quoted fields now decode UTF-16 surrogate pairs (`\uXXXX\uXXXX`) into the
+  code point they encode, matching `serde_json`, so fields named with emoji
+  and other non-BMP characters can be queried via their JSON escape form.
+  Previously both halves were silently dropped, producing a wrong (often
+  empty) field name. A surrogate half that is not part of a valid high+low
+  pair is now a parse error instead of being silently discarded.
 
 ### Breaking
 

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -312,7 +312,7 @@ fn parse_field(
 
     // Quoted fields: strip the surrounding double quotes and unescape
     let name = if raw.starts_with('"') && raw.ends_with('"') && raw.len() >= 2 {
-        unescape_json_string(&raw[1..raw.len() - 1])
+        unescape_json_string(&raw[1..raw.len() - 1])?
     } else {
         raw.to_string()
     };
@@ -333,7 +333,12 @@ fn parse_field(
 /// - `\r` -> carriage return (U+000D)
 /// - `\t` -> tab (U+0009)
 /// - `\uXXXX` -> the Unicode code point U+XXXX
-fn unescape_json_string(s: &str) -> String {
+///
+/// Code points outside the Basic Multilingual Plane are written as UTF-16
+/// surrogate pairs (`\uD83D\uDE00` for U+1F600), which are combined into the
+/// single code point they encode, matching `serde_json`. A surrogate half
+/// that is not part of a valid high+low pair is an error.
+fn unescape_json_string(s: &str) -> Result<String, QueryParseError> {
     let mut result = String::with_capacity(s.len());
     let mut chars = s.chars();
 
@@ -349,15 +354,37 @@ fn unescape_json_string(s: &str) -> String {
                 Some('r') => result.push('\r'),
                 Some('t') => result.push('\t'),
                 Some('u') => {
-                    // Collect exactly 4 hex digits
-                    let hex: String = chars.by_ref().take(4).collect();
-                    if let Ok(code_point) = u32::from_str_radix(&hex, 16)
-                        && let Some(ch) = char::from_u32(code_point)
-                    {
-                        result.push(ch);
+                    let unit = parse_hex4(&mut chars)?;
+                    match unit {
+                        // High surrogate: must be followed by a low
+                        // surrogate escape; combine into one code point.
+                        0xD800..=0xDBFF => {
+                            if chars.next() != Some('\\')
+                                || chars.next() != Some('u')
+                            {
+                                return Err(lone_surrogate_error(unit));
+                            }
+                            let low = parse_hex4(&mut chars)?;
+                            if !(0xDC00..=0xDFFF).contains(&low) {
+                                return Err(lone_surrogate_error(unit));
+                            }
+                            let code_point = 0x10000
+                                + ((unit - 0xD800) << 10)
+                                + (low - 0xDC00);
+                            result.push(
+                                char::from_u32(code_point)
+                                    .expect("valid surrogate pair"),
+                            );
+                        }
+                        // Low surrogate with no preceding high surrogate
+                        0xDC00..=0xDFFF => {
+                            return Err(lone_surrogate_error(unit));
+                        }
+                        _ => result.push(
+                            char::from_u32(unit)
+                                .expect("non-surrogate BMP code point"),
+                        ),
                     }
-                    // Silently skip invalid code points — the pest
-                    // grammar already validates the 4-hex-digit format
                 }
                 Some(other) => {
                     // Unrecognized escape: preserve as-is
@@ -374,7 +401,33 @@ fn unescape_json_string(s: &str) -> String {
         }
     }
 
-    result
+    Ok(result)
+}
+
+/// Read exactly four hex digits of a `\uXXXX` escape from `chars`.
+///
+/// The pest grammar guarantees quoted fields contain well-formed escapes, so
+/// this only fails for strings that bypass the grammar.
+fn parse_hex4(chars: &mut std::str::Chars<'_>) -> Result<u32, QueryParseError> {
+    let hex: String = chars.by_ref().take(4).collect();
+    if hex.len() == 4
+        && let Ok(unit) = u32::from_str_radix(&hex, 16)
+    {
+        Ok(unit)
+    } else {
+        Err(QueryParseError::UnexpectedToken(format!(
+            "invalid \\u escape \"\\u{hex}\": expected 4 hex digits"
+        )))
+    }
+}
+
+/// Error for a UTF-16 surrogate half that is not part of a valid pair.
+fn lone_surrogate_error(unit: u32) -> QueryParseError {
+    QueryParseError::UnexpectedToken(format!(
+        "lone surrogate \\u{unit:04X} in quoted field: characters outside \
+         the Basic Multilingual Plane must be written as a \\uXXXX\\uXXXX \
+         high+low surrogate pair"
+    ))
 }
 
 /// Parse a group rule into a [`Query::Disjunction`].
@@ -772,6 +825,78 @@ mod tests {
         assert_eq!(result, Query::Sequence(vec![Query::Field("A".into())]));
         // 'A' has no reserved chars, so displayed unquoted
         assert_eq!("A", result.to_string());
+    }
+
+    #[test]
+    fn quoted_field_surrogate_pair_combined() {
+        // \uD83D\uDE00 is the UTF-16 surrogate pair for 😀 (U+1F600)
+        let result = parse_query(r#""\uD83D\uDE00""#).unwrap();
+        assert_eq!(result, Query::Sequence(vec![Query::Field("😀".into())]));
+        // 😀 has no reserved chars, so it is displayed unquoted
+        assert_eq!("😀", result.to_string());
+    }
+
+    #[test]
+    fn quoted_field_surrogate_pair_with_surrounding_text() {
+        let result = parse_query(r#""a\uD83D\uDE00b""#).unwrap();
+        assert_eq!(result, Query::Sequence(vec![Query::Field("a😀b".into())]));
+    }
+
+    #[test]
+    fn quoted_field_surrogate_pair_boundaries() {
+        // Lowest surrogate pair: \uD800\uDC00 encodes U+10000
+        let result = parse_query(r#""\uD800\uDC00""#).unwrap();
+        assert_eq!(
+            result,
+            Query::Sequence(vec![Query::Field("\u{10000}".into())])
+        );
+
+        // Highest surrogate pair: \uDBFF\uDFFF encodes U+10FFFF
+        let result = parse_query(r#""\uDBFF\uDFFF""#).unwrap();
+        assert_eq!(
+            result,
+            Query::Sequence(vec![Query::Field("\u{10FFFF}".into())])
+        );
+    }
+
+    #[test]
+    fn quoted_field_consecutive_surrogate_pairs() {
+        // 😀 (U+1F600) followed by 😁 (U+1F601), both escaped
+        let result = parse_query(r#""\uD83D\uDE00\uD83D\uDE01""#).unwrap();
+        assert_eq!(result, Query::Sequence(vec![Query::Field("😀😁".into())]));
+    }
+
+    #[test]
+    fn unescape_rejects_truncated_hex() {
+        // Unreachable through parse_query (the grammar validates the
+        // 4-hex-digit format), but documents the defensive behaviour of
+        // the raw unescape path.
+        let err = unescape_json_string(r"\uD8").unwrap_err();
+        assert!(err.to_string().contains("expected 4 hex digits"), "{err}");
+    }
+
+    #[test]
+    fn quoted_field_lone_high_surrogate_rejected() {
+        let err = parse_query(r#""\uD83D""#).unwrap_err();
+        assert!(err.to_string().contains("lone surrogate"), "{err}");
+    }
+
+    #[test]
+    fn quoted_field_lone_low_surrogate_rejected() {
+        let err = parse_query(r#""\uDE00""#).unwrap_err();
+        assert!(err.to_string().contains("lone surrogate"), "{err}");
+    }
+
+    #[test]
+    fn quoted_field_high_surrogate_followed_by_non_surrogate_rejected() {
+        let err = parse_query(r#""\uD83D\u0041""#).unwrap_err();
+        assert!(err.to_string().contains("lone surrogate"), "{err}");
+    }
+
+    #[test]
+    fn quoted_field_high_surrogate_followed_by_plain_char_rejected() {
+        let err = parse_query(r#""\uD83Dx""#).unwrap_err();
+        assert!(err.to_string().contains("lone surrogate"), "{err}");
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -161,6 +161,37 @@ mod tests {
     }
 
     #[test]
+    fn quoted_field_surrogate_pair_escape_matches() {
+        let mut cmd =
+            Command::cargo_bin("jg").expect("Failed to find main binary");
+        let assert = cmd
+            .args(["-f", "json", r#""\uD83D\uDE00""#, "--no-path", "--compact"])
+            .write_stdin(r#"{"😀": "grin"}"#)
+            .assert()
+            .success()
+            .code(0);
+        let output = String::from_utf8(assert.get_output().stdout.clone())
+            .expect("Invalid UTF-8 output");
+        assert_eq!(
+            output.trim(),
+            r#""grin""#,
+            "surrogate-pair escape should match the emoji key"
+        );
+    }
+
+    #[test]
+    fn quoted_field_lone_surrogate_is_clean_error() {
+        let assert =
+            run_main(&[r#""\uD83D""#, SIMPLE_JSON_FILEPATH]).failure().code(1);
+        let stderr = String::from_utf8(assert.get_output().stderr.clone())
+            .expect("Invalid UTF-8 output");
+        assert!(
+            stderr.contains("lone surrogate"),
+            "expected lone surrogate parse error, got: {stderr:?}"
+        );
+    }
+
+    #[test]
     fn fixed_string_finds_key_at_any_depth() {
         let assert =
             run_main(&["-F", "/activities", "tests/data/openapi_paths.json"])

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -201,7 +201,7 @@ mod tests {
     #[test]
     fn quoted_field_lone_surrogate_is_clean_error() {
         let assert =
-            run_main(&[r#""\uD83D""#, SIMPLE_JSON_FILEPATH]).failure().code(1);
+            run_main(&[r#""\uD83D""#, SIMPLE_JSON_FILEPATH]).failure().code(2);
         let stderr = String::from_utf8(assert.get_output().stderr.clone())
             .expect("Invalid UTF-8 output");
         assert!(


### PR DESCRIPTION
unescape_json_string pushed each \uXXXX escape through char::from_u32,
which returns None for surrogate halves, so both halves of a pair like
\uD83D\uDE00 were silently dropped: the query "\uD83D\uDE00" produced
an empty field name instead of matching a key named with U+1F600, and
any lone surrogate was likewise swallowed without a diagnostic.

Combine high+low surrogate pairs into the code point they encode,
matching serde_json's behaviour for the same escapes, and return a
parse error naming the offending half when a surrogate is not part of
a valid high+low pair (lone high at end of string, high followed by a
non-escape or a non-low escape, bare low). Non-surrogate BMP escapes
are unchanged.

Evidence: before this change `jg '"\uD83D\uDE00"'` over {"\uD83D\uDE00":"grin"}
returned nothing; it now prints "grin", and `jg '"\uD83D"'` fails with
'lone surrogate \uD83D in quoted field' instead of silently matching
the empty field name. Covered by seven new parser unit tests (pair,
pair with surrounding text, boundary pairs U+10000 and U+10FFFF,
consecutive pairs, lone high/low, high followed by non-surrogate
escape and by a plain character, truncated hex on the defensive
non-grammar path) and two CLI tests (match via escape form over stdin,
clean exit-code-1 error on a lone surrogate).

