### PR TITLE
fix(grammar): accept chained array accesses like foo[0][1]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--compact` is implied, so output is one machine-parseable JSON value
   per line. Previously only the `--count`/`--depth` labels were
   affected.
+- Chained array accesses now parse: `foo[0][1]`, `foo[0][1:3][*]`, etc.
+  Previously the grammar allowed only one array access per step, so these
+  familiar jq/JSONPath forms were rejected with a parse error and users had
+  to write `foo[0].[1]` instead (which remains valid and is the canonical
+  display form). A trailing `?`/`*` modifier binds to the last access,
+  matching the existing single-access behaviour.
 
 ### Breaking
 

--- a/src/query/grammar/query.pest
+++ b/src/query/grammar/query.pest
@@ -30,10 +30,10 @@ group           = { "(" ~ disjunction ~ ")" }
 /// Sequence of queries
 sequence        = { step ~ ("." ~ step)* }
 
-/// Step in a sequence - can be an atom with modifiers, or a field with array
-/// accesses
+/// Step in a sequence - can be an atom with modifiers, or a field with any
+/// number of chained array accesses, e.g. "foo[0][1]"
 step            = {
-                    (field ~ (index | range | array_wildcard)?) ~ modifier?
+                    (field ~ (index | range | array_wildcard)*) ~ modifier?
                     | atom ~ modifier?
                     | group ~ modifier?
                   }

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -546,6 +546,78 @@ mod tests {
     }
 
     #[test]
+    fn parse_chained_array_accesses() {
+        let result = parse_query("foo[0][1]").unwrap();
+        assert_eq!(
+            result,
+            Query::Sequence(vec![Query::Sequence(vec![
+                Query::Field("foo".into()),
+                Query::Index(0),
+                Query::Index(1),
+            ])])
+        );
+        // Canonical display separates subsequent accesses with '.'
+        assert_eq!("foo[0].[1]", result.to_string());
+        // ...and the canonical form is reparseable with a stable display
+        // (the reparsed AST nests differently but display is idempotent;
+        // semantic equivalence is covered by the CLI matching test)
+        let reparsed = parse_query(&result.to_string()).unwrap();
+        assert_eq!(result.to_string(), reparsed.to_string());
+    }
+
+    #[test]
+    fn parse_chained_accesses_kleene_binds_to_last() {
+        let result = parse_query("foo[0][1]*").unwrap();
+        assert_eq!(
+            result,
+            Query::Sequence(vec![Query::Sequence(vec![
+                Query::Field("foo".into()),
+                Query::Index(0),
+                Query::KleeneStar(Box::new(Query::Index(1))),
+            ])])
+        );
+    }
+
+    #[test]
+    fn parse_access_after_modifier_rejected() {
+        // The modifier ends the step; a further access needs a '.' separator
+        let result = parse_query("foo[0]?[1]");
+        assert!(
+            matches!(result, Err(QueryParseError::UnexpectedToken(_))),
+            "Actual result: {result:?}"
+        );
+    }
+
+    #[test]
+    fn parse_chained_mixed_accesses() {
+        let result = parse_query("foo[0][1:3][*]").unwrap();
+        assert_eq!(
+            result,
+            Query::Sequence(vec![Query::Sequence(vec![
+                Query::Field("foo".into()),
+                Query::Index(0),
+                Query::Range(Some(1), Some(3)),
+                Query::ArrayWildcard,
+            ])])
+        );
+    }
+
+    #[test]
+    fn parse_chained_accesses_with_modifier() {
+        // The modifier binds to the last access, matching the existing
+        // single-access behaviour of e.g. "foo[0]?"
+        let result = parse_query("foo[0][1]?").unwrap();
+        assert_eq!(
+            result,
+            Query::Sequence(vec![Query::Sequence(vec![
+                Query::Field("foo".into()),
+                Query::Index(0),
+                Query::Optional(Box::new(Query::Index(1))),
+            ])])
+        );
+    }
+
+    #[test]
     fn parse_multiple_optional() {
         let query = "c*.c?.c?";
         let result = parse_query(query).unwrap();

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -137,6 +137,25 @@ mod tests {
         assert_eq!(output_json, expected_json);
     }
 
+    #[test]
+    fn chained_array_accesses_match() {
+        let mut cmd =
+            Command::cargo_bin("jg").expect("Failed to find main binary");
+        let assert = cmd
+            .args(["-f", "json", "grid[1][0]", "--no-path", "--compact"])
+            .write_stdin(r#"{"grid": [[1, 2], [3, 4]]}"#)
+            .assert()
+            .success()
+            .code(0);
+        let output = String::from_utf8(assert.get_output().stdout.clone())
+            .expect("Invalid UTF-8 output");
+        assert_eq!(
+            output.trim(),
+            "3",
+            "chained accesses grid[1][0] should match the nested element"
+        );
+    }
+
     // ==============================================================================
     // Quoted field and --fixed-string tests
     // ==============================================================================


### PR DESCRIPTION
The step rule allowed at most one array access after a field
(index | range | array_wildcard)?, so the familiar jq/JSONPath forms
foo[0][1] and foo[0][1:3][*] were parse errors and users had to write
foo[0].[1]. Meanwhile parse_step already contained a loop consuming
multiple consecutive accesses - dead code the grammar could never
reach.

Change the grammar repetition from ? to *, which activates that loop
unchanged. A trailing ?/* modifier still binds to the last access,
matching the existing foo[0]? behaviour, and a modifier still ends the
step (foo[0]?[1] remains a parse error). The canonical Display form
stays foo[0].[1], which is reparseable with a stable display.

Evidence: `jg 'grid[1][0]'` over {"grid":[[1,2],[3,4]]} previously
failed with a parse error and now prints 3. Covered by five new parser
unit tests (two indices, mixed index/range/wildcard chain, optional
and Kleene binding to the last access, access-after-modifier still
rejected) and a CLI test matching a nested array element end to end.
Codex review found no new grammar ambiguity and confirmed the NFA/DFA
construction handles the resulting Sequence shapes; it also flagged a
pre-existing Display quirk (bar.* rendering as bar*) which is tracked
separately and unchanged here.

