### PR TITLE
fix(ast): keep '.' separator where omitting it changes query meaning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--compact` is implied, so output is one machine-parseable JSON value
   per line. Previously only the `--count`/`--depth` labels were
   affected.
+- `Query` display no longer renders `foo.*` (field then field wildcard) as
+  `foo*`, which reparsed as `foo` repeated zero or more times - a different
+  query. Likewise `foo*.[0]` no longer renders as `foo*[0]`, which did not
+  reparse at all. The `.` separator is now omitted only between a bare field
+  and its array access, so displaying and reparsing a query preserves its
+  meaning.
 
 ### Breaking
 

--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -175,27 +175,28 @@ impl Display for Query {
                     if i > 0
                         && let Some(prev_query) = queries.get(i - 1)
                     {
-                        /* Handle optional modifiers -> extract inner queries */
+                        /* A modifier ("?" or Kleene star) on the current step
+                         * applies to the access itself (e.g. "foo[0]?"), so
+                         * unwrap it before deciding on a separator. */
                         let inner_query = match query {
                             Self::Optional(inner) | Self::KleeneStar(inner) => {
                                 inner
                             }
                             _ => query,
                         };
-                        let prev_inner = match prev_query {
-                            Self::Optional(inner) | Self::KleeneStar(inner) => {
-                                inner
-                            }
-                            _ => prev_query,
-                        };
-                        /* Handle field accessed followed by a ranged accessed. */
-                        match (prev_inner, inner_query) {
+                        /* Omit the '.' only between a bare field and its array
+                         * access, mirroring the grammar's field ~ access form.
+                         * The previous step must NOT be unwrapped: a modified
+                         * field like "foo*" needs the separator ("foo*[0]" is
+                         * not parseable), and FieldWildcard must not join the
+                         * access set ("foo.*" rendered as "foo*" would reparse
+                         * as KleeneStar(foo), a different query). */
+                        match (prev_query, inner_query) {
                             (
                                 Self::Field(_),
                                 Self::Index(_)
                                 | Self::Range(_, _)
                                 | Self::RangeFrom(_)
-                                | Self::FieldWildcard
                                 | Self::ArrayWildcard,
                             ) => {
                                 // continue; no '.' separator

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -553,6 +553,57 @@ mod tests {
     }
 
     #[test]
+    fn field_then_wildcard_display_roundtrip() {
+        let query = "foo.*";
+        let result = parse_query(query).unwrap();
+        assert_eq!(
+            result,
+            Query::Sequence(vec![
+                Query::Field("foo".into()),
+                Query::FieldWildcard,
+            ])
+        );
+        // Regression: this used to display as "foo*", which reparses as
+        // KleeneStar(foo) - a different query.
+        assert_eq!(query, result.to_string());
+        assert_eq!(result, parse_query(&result.to_string()).unwrap());
+    }
+
+    #[test]
+    fn modified_field_then_access_display_roundtrip() {
+        // Regression: "foo*.[0]" used to display as "foo*[0]", which does
+        // not reparse (the grammar requires accesses before the modifier).
+        for query in ["foo*.[0]", "foo?.[0]", "foo?.[1:3]", "foo*.[*]"] {
+            let result = parse_query(query).unwrap();
+            assert_eq!(query, &result.to_string());
+            assert_eq!(result, parse_query(&result.to_string()).unwrap());
+        }
+    }
+
+    #[test]
+    fn field_then_modified_access_display_roundtrip() {
+        // The no-separator form is kept when the modifier is on the access
+        for query in ["foo[0]?", "foo[0]*", "foo[1:3]?", "foo[*]?"] {
+            let result = parse_query(query).unwrap();
+            assert_eq!(query, &result.to_string());
+            assert_eq!(result, parse_query(&result.to_string()).unwrap());
+        }
+    }
+
+    #[test]
+    fn kleene_star_display_unchanged() {
+        let query = "foo*";
+        let result = parse_query(query).unwrap();
+        assert_eq!(
+            result,
+            Query::Sequence(vec![Query::KleeneStar(Box::new(Query::Field(
+                "foo".into()
+            )))])
+        );
+        assert_eq!(query, result.to_string());
+    }
+
+    #[test]
     fn parse_simple_disjunction_group() {
         let query = "(foo | bar).baz";
         let result = parse_query(query).unwrap();


### PR DESCRIPTION
Sequence display omitted the '.' separator in two unsound cases:

1. Between a Field and a following FieldWildcard: "foo.*" displayed as
   "foo*", which reparses as KleeneStar(Field("foo")) - repeat foo zero
   or more times instead of any single field under foo. Silent
   semantics change on any display/reparse round trip.

2. The previous step's Optional/KleeneStar wrapper was unwrapped before
   the separator decision, so "foo*.[0]" displayed as "foo*[0]", which
   does not parse at all (the grammar requires array accesses before
   the modifier).

Omit the separator only between a bare Field and a following array
access (index, range, array wildcard), exactly mirroring the grammar's
field ~ access step form. The current step is still unwrapped so
"foo[0]?" keeps its no-dot rendering, which reparses identically.

Both bugs date to the introduction of the separator logic; no code
depends on the old renderings (confirmed by codex review and a clean
test run - no existing test asserted "foo*" or "foo*[0]" output).
Covered by four new round-trip tests over twelve query forms.

