### PR TITLE
fix(ast): parenthesize modified display operands that need it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reparse at all. The `.` separator is now omitted only between a bare field
   and its array access, so displaying and reparsing a query preserves its
   meaning.
+- `Query` display now parenthesizes a `?`/`*` operand that itself carries a
+  modifier: `(foo?)*` used to display as `foo?*`, which does not reparse
+  (the grammar allows one modifier per step). Redundant parentheses around
+  a single plain step still collapse (`(foo)?` displays as `foo?`). A
+  modifier on an empty operand (reachable via `QueryBuilder::new()
+.optional()`) now displays as the empty query it denotes instead of an
+  unparseable bare `?`.
 
 ### Breaking
 

--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -137,26 +137,27 @@ impl Display for Query {
             Self::FieldWildcard => write!(f, "*"),
             Self::ArrayWildcard => write!(f, "[*]"),
             Self::Regex(re) => write!(f, "/{re}/"),
-            Self::Optional(q) => match &**q {
-                Self::Disjunction(queries) | Self::Sequence(queries) => {
-                    if queries.len() > 1 {
-                        write!(f, "({q})?")
-                    } else {
-                        write!(f, "{q}?")
-                    }
+            Self::Optional(q) => {
+                if displays_as_empty(q) {
+                    // Optional(empty) denotes the empty query; "()?" would
+                    // not reparse (a group cannot be empty)
+                    Ok(())
+                } else if modifier_operand_needs_parens(q) {
+                    write!(f, "({q})?")
+                } else {
+                    write!(f, "{q}?")
                 }
-                _ => write!(f, "{q}?"),
-            },
-            Self::KleeneStar(q) => match &**q {
-                Self::Disjunction(queries) | Self::Sequence(queries) => {
-                    if queries.len() > 1 {
-                        write!(f, "({q})*")
-                    } else {
-                        write!(f, "{q}*")
-                    }
+            }
+            Self::KleeneStar(q) => {
+                if displays_as_empty(q) {
+                    // KleeneStar(empty) likewise denotes the empty query
+                    Ok(())
+                } else if modifier_operand_needs_parens(q) {
+                    write!(f, "({q})*")
+                } else {
+                    write!(f, "{q}*")
                 }
-                _ => write!(f, "{q}*"),
-            },
+            }
             Self::Disjunction(queries) => {
                 let joined = queries
                     .iter()
@@ -215,6 +216,40 @@ impl Display for Query {
                 Ok(())
             }
         }
+    }
+}
+
+/// Returns `true` if a query displayed as the operand of a postfix `?`/`*`
+/// modifier needs surrounding parentheses to reparse with the same meaning.
+/// A single step never does; a multi-step sequence or disjunction does; a
+/// single-element wrapper is decided by its element (e.g. the sequence
+/// holding `foo?` inside `(foo?)*` still needs them, since `foo?*` does not
+/// parse - the grammar allows one modifier per step).
+fn modifier_operand_needs_parens(query: &Query) -> bool {
+    match query {
+        Query::Sequence(queries) | Query::Disjunction(queries) => {
+            queries.len() != 1 || modifier_operand_needs_parens(&queries[0])
+        }
+        Query::Optional(_) | Query::KleeneStar(_) => true,
+        _ => false,
+    }
+}
+
+/// Returns `true` if a query displays as the empty string (an empty
+/// sequence or nothing but nested empty wrappers). A postfix modifier on
+/// such an operand is dropped by `Display`: `Optional`/`KleeneStar` of the
+/// empty query both denote the empty query, and rendering `()?` would not
+/// reparse (a group cannot be empty). Reachable via
+/// `QueryBuilder::new().optional()`.
+fn displays_as_empty(query: &Query) -> bool {
+    match query {
+        Query::Sequence(queries) | Query::Disjunction(queries) => {
+            queries.iter().all(displays_as_empty)
+        }
+        Query::Optional(inner) | Query::KleeneStar(inner) => {
+            displays_as_empty(inner)
+        }
+        _ => false,
     }
 }
 

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -773,6 +773,41 @@ mod tests {
     }
 
     #[test]
+    fn modifier_on_modified_group_display_roundtrip() {
+        // Regression: these used to display without the parentheses
+        // ("foo?*", "(a | b)?*", ...), which does not reparse - the grammar
+        // allows only one modifier per step.
+        for query in ["(foo?)*", "(foo*)?", "((a | b)?)*", "((a | b)*)?"] {
+            let result = parse_query(query).unwrap();
+            assert_eq!(query, &result.to_string());
+            assert_eq!(result, parse_query(&result.to_string()).unwrap());
+        }
+    }
+
+    #[test]
+    fn modifier_on_trivial_group_normalizes() {
+        // Redundant parens around a single step still collapse
+        let result = parse_query("(foo)?").unwrap();
+        assert_eq!("foo?", result.to_string());
+    }
+
+    #[test]
+    fn modifier_on_empty_operand_displays_empty() {
+        // Optional/KleeneStar of the empty query denote the empty query;
+        // displaying "()?" (or the old bare "?") would not reparse.
+        // Reachable via QueryBuilder::new().optional().
+        let optional_empty = Query::Optional(Box::new(Query::Sequence(vec![])));
+        assert_eq!("", optional_empty.to_string());
+        assert_eq!(
+            Query::Sequence(vec![]),
+            parse_query(&optional_empty.to_string()).unwrap()
+        );
+
+        let star_empty = Query::KleeneStar(Box::new(Query::Sequence(vec![])));
+        assert_eq!("", star_empty.to_string());
+    }
+
+    #[test]
     fn parse_invalid_number() {
         let result = parse_query("foo[abc]");
         assert!(


### PR DESCRIPTION
Display for Optional/KleeneStar decided parentheses with a len > 1
check on Sequence/Disjunction operands, so any single-element operand
lost its parens even when its element carried a modifier:
parse("(foo?)*").to_string() gave "foo?*", parse("(foo*)?") gave
"foo*?", and parse("((a | b)?)*") gave "(a | b)?*" - none of which
reparse, since the grammar allows one modifier per step. All three are
reachable from surface syntax, breaking any display/reparse round
trip.

Replace the heuristic with a recursive modifier_operand_needs_parens:
multi-element sequences/disjunctions and modifier-wrapped operands
need parens; a single-element wrapper is decided by its element; atoms
never need them. Redundant parens around a single plain step still
collapse ("(foo)?" displays as "foo?").

Also fix the empty-operand case codex flagged in review: a modifier on
an empty query (reachable via QueryBuilder::new().optional()) used to
display as a bare "?" and would have become "()?" - both unparseable.
Optional/KleeneStar of the empty query denote the empty query, so
Display now emits nothing for them.

Covered by new round-trip tests over the four modified-group forms,
the trivial-group collapse, and the empty-operand builder path. No
existing test asserted the old broken renderings.

