### PR TITLE
ci: test on macOS/Windows, add MSRV job, cache, full-target clippy, doc gate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,27 +2,71 @@ name: Rust
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 env:
   CARGO_TERM_COLOR: always
 
+# Third-party actions are pinned to commit SHAs (tag in trailing comment).
+# GitHub-owned actions (actions/*) are pinned to major version tags.
 jobs:
-  build:
-
-    runs-on: ubuntu-latest
-
+  test:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-    - uses: actions/checkout@v4
-    - name: Build
-      run: cargo build --verbose
-    - name: Build (no default features)
-      run: cargo check --no-default-features --verbose
-    - name: Run tests
-      run: cargo test --verbose
-    - name: Run Clippy
-      run: cargo clippy --verbose -- -D warnings
-    - name: Check formatting
-      run: cargo fmt --check
+      - uses: actions/checkout@v6
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Build
+        run: cargo build --verbose
+      - name: Build (no default features)
+        run: cargo check --no-default-features --verbose
+      - name: Run tests
+        run: cargo test --verbose
+
+  lint:
+    name: Lint (fmt, clippy, docs)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      # Benches include_str! fixtures from the schemastore submodule, so
+      # clippy --all-targets needs it. Fetch just that submodule, shallow -
+      # the other submodules total ~700 MB and nothing compiles against them.
+      - name: Fetch schemastore submodule (bench fixtures)
+        run: git submodule update --init --depth 1 tests/data/schemastore
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+          components: clippy, rustfmt
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Check formatting
+        run: cargo fmt --check
+      - name: Run Clippy (all targets, including benches)
+        run: cargo clippy --all-targets --verbose -- -D warnings
+      - name: Check documentation
+        run: cargo doc --no-deps --verbose
+        env:
+          RUSTDOCFLAGS: -D warnings
+
+  msrv:
+    name: MSRV (1.88)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Rust 1.88
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: "1.88"
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Check with MSRV
+        run: cargo check --verbose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `jsongrep::utils::write_colored_result` now takes a `WriteOptions` struct
   instead of separate `pretty`, `show_path`, and `raw` parameters.
 
+### Internal
+
+- CI now tests on macOS and Windows in addition to Ubuntu (the platforms
+  release binaries ship for), adds an MSRV check (`rust-version = "1.88"`,
+  required by let-chains under edition 2024), caches builds with
+  `rust-cache`, runs clippy over all targets including benches (with a
+  shallow schemastore submodule fetch for the bench fixtures), and treats
+  rustdoc warnings as errors. Third-party actions are pinned to commit
+  SHAs.
+
 ## [0.9.0] - 2026-04-18
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "jsongrep"
 version = "0.9.0"
 authors = ["Micah Kepe <micahkepe@gmail.com>"]
 edition = "2024"
+rust-version = "1.88"
 readme = "README.md"
 license = "MIT"
 repository = "https://github.com/micahkepe/jsongrep"

--- a/src/query/ast.rs
+++ b/src/query/ast.rs
@@ -96,7 +96,8 @@ impl Query {
         Self::Field(name.into())
     }
 
-    /// Envelopes the fixed query string with a recursive depth "(* | [*])" prelude.
+    /// Envelopes the fixed query string with a recursive depth `(* | [*])*`
+    /// prelude.
     ///
     /// NOTE: Used mainly for `-F`/ `--fixed-string` CLI flag.
     pub fn recursive_depth_fixed_string<T: Into<String>>(fixed: T) -> Self {

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -61,7 +61,8 @@ use crate::query::Query;
 mod pest_parser {
     use pest_derive::Parser;
 
-    /// Parser for turning raw query strings into [`Query`] objects.
+    /// Parser for turning raw query strings into
+    /// [`Query`](crate::query::Query) objects.
     #[derive(Parser)]
     #[grammar = "query/grammar/query.pest"]
     pub struct QueryDSLParser;


### PR DESCRIPTION
The repo ships release binaries for macOS and Windows (and auto-bumps a
Homebrew formula) but tested only on Ubuntu. Changes to rust.yml:

- Test job becomes a 3-OS matrix (ubuntu/macos/windows, fail-fast off).
- New lint job: cargo fmt --check, clippy --all-targets -D warnings
  (now covers tests and benches; benches include_str! fixtures from the
  schemastore submodule, fetched alone and shallow - the other
  submodules total ~700 MB and nothing compiles against them), and
  cargo doc --no-deps with rustdoc warnings as errors.
- New MSRV job checking with Rust 1.88, plus rust-version = "1.88" in
  Cargo.toml so cargo enforces it for consumers. 1.88 is the true
  minimum: the code uses let-chains, stabilized in 1.88 under edition
  2024 (verified locally - cargo +1.88 check --all-targets passes).
- Swatinem/rust-cache on every job.
- Third-party actions (dtolnay/rust-toolchain, Swatinem/rust-cache)
  pinned to commit SHAs with the tag in a trailing comment;
  actions/checkout unified to v6 to match deploy-playground.yml.

Also fixes the two rustdoc intra-doc-link warnings the new doc gate
would trip on (unescaped [*] in ast.rs, out-of-scope [Query] link in
the pest wrapper module).

Workflow validated with actionlint. This PR's own CI run is the first
ever macOS/Windows test execution for the repo.

