### PR TITLE
ci(release): gate cargo publish on tests and binary builds; pin actions by SHA

### DIFF
--- a/.github/workflows/homebrew-release.yml
+++ b/.github/workflows/homebrew-release.yml
@@ -9,7 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Bump Homebrew formula
-        uses: mislav/bump-homebrew-formula-action@v3
+        # Pinned to a commit SHA: this action receives a push-capable PAT
+        # (HOMEBREW_GITHUB_API_TOKEN), and "v3" is a moving branch, so an
+        # upstream compromise would hand that token to attacker-controlled
+        # code on the next release. SHA = v3 branch head of 2025-09-16
+        # (post-v3.4), i.e. exactly what "@v3" resolved to when pinned.
+        uses: mislav/bump-homebrew-formula-action@56a283fa15557e9abaa4bdb63b8212abc68e655c # v3 (2025-09-16)
         with:
           formula-name: jsongrep
           tag-name: ${{ github.event.release.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Extract version from tag
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
       - name: Verify Cargo.toml version
@@ -38,15 +38,34 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release create "$GITHUB_REF_NAME" --draft --title "$GITHUB_REF_NAME" --notes "Release $VERSION of jsongrep"
 
+  test:
+    name: Test before publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+      - name: Run tests
+        run: cargo test --verbose
+
+  # Publishing to crates.io is irreversible (versions can only be yanked,
+  # never replaced), so gate it on the test run and on every release
+  # binary building successfully.
   publish-crates:
     name: Publish to crates.io
-    needs: create-release
+    needs: [create-release, test, build-release]
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
       - name: Publish to crates.io
         run: cargo publish
         env:
@@ -82,12 +101,13 @@ jobs:
             ext: ".exe"
             strip: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag || github.ref }}
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
+          toolchain: stable
           target: ${{ matrix.target }}
       - name: Install cross-compilation tools (Linux ARM64)
         if: matrix.cross

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `jsongrep::utils::write_colored_result` now takes a `WriteOptions` struct
   instead of separate `pretty`, `show_path`, and `raw` parameters.
 
-### Internal
+### Changed
 
 - CI now tests on macOS and Windows in addition to Ubuntu (the platforms
   release binaries ship for), adds an MSRV check (`rust-version = "1.88"`,
@@ -54,6 +54,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   shallow schemastore submodule fetch for the bench fixtures), and treats
   rustdoc warnings as errors. Third-party actions are pinned to commit
   SHAs.
+- Release workflow: `cargo publish` is now gated on a test run and on all
+  five release binaries building (publishing is irreversible); third-party
+  actions are pinned to commit SHAs, including the Homebrew bump action
+  which holds a push-capable PAT and was previously pinned to a moving
+  branch; checkout action unified to v6.
 
 ## [0.9.0] - 2026-04-18
 


### PR DESCRIPTION
Two hardening changes to the release pipeline:

1. cargo publish was gated only on the GitHub release being created -
   a release could publish to crates.io (irreversible; versions can
   only be yanked, never replaced) even if the code failed tests or
   some release binaries failed to build. Add a test job to the
   release workflow and make publish-crates need it plus build-release,
   so publishing happens only after tests pass and all five targets
   build. workflow_dispatch behaviour is unchanged (publish still
   skips).

2. Pin third-party actions to commit SHAs with the resolved ref in a
   trailing comment. The important one is
   mislav/bump-homebrew-formula-action: it receives a push-capable PAT
   (HOMEBREW_GITHUB_API_TOKEN), and its "@v3" reference is a moving
   branch (currently a post-v3.4 merge from 2025-09-16, matching no
   release tag), so an upstream compromise would hand that token to
   attacker-controlled code on the next release. The pinned SHA is
   exactly what @v3 resolves to today - no behaviour change.
   dtolnay/rust-toolchain is pinned the same way, and actions/checkout
   is unified to v6 across the release workflow to match
   deploy-playground.yml.

Validated with actionlint (remaining SC2086 notes are pre-existing in
the archive scripts and untouched here).

